### PR TITLE
Add field for "note_taking": "new_note_url"

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,13 +38,13 @@
       </p>
     </section>
     <section>
-      <h2 data-dft-for="">
+      <h2 data-dfn-for="">
         <code>display_override</code> member
       </h2>
       <p>
         For advanced usages, the display_override member can be used to specify
         a custom fallback order of {DisplayModeType}}s for developers to choose
-        their prefered <a data-cite="appmanifest#dfn-display-mode">display
+        their preferred <a data-cite="appmanifest#dfn-display-mode">display
         mode</a>.
       </p>
       <p>
@@ -109,6 +109,56 @@
             "display": "standalone",
             "theme_color": "yellow",
             "background_color": "red"
+          }
+        </pre>
+      </section>
+    </section>
+    <section>
+      <h2>
+        <code><dfn>note_taking</dfn></code> member
+      </h2>
+      <p>
+        The <code>note_taking</code> member of the <a data-cite=
+        "appmanifest#web-application-manifest">Web Application Manifest</a> is
+        an <a data-cite="appmanifest#dfn-object">object</a> that contains
+        information related to note-taking. It has the following members:
+      </p>
+      <ul>
+        <li>[=note_taking/new_note_url=]
+        </li>
+      </ul>
+      <section>
+        <h3>
+          <code><dfn data-dfn-for="note_taking">new_note_url</dfn></code> member
+        </h3>
+        <p>
+          The [=note_taking=] <code>new_note_url</code> member is a <a>URL</a>
+          [=manifest/within scope=] to open when the user wants to take a new
+          note using the web application (e.g., from an operating system
+          shortcut icon or keyboard shortcut). Defining this member indicates
+          that the web application is a note-taking application.
+        </p>
+      </section>
+      <section class="informative">
+        <h3>
+          Usage Example
+        </h3>
+        <p>
+          The following shows a [=manifest=] for a note-taking application.
+        </p>
+        <pre class="example json" title="Note-taking application">
+          {
+            "name": "My Note Taking App",
+            "description": "You can take notes!",
+            "icons": [{
+              "src": "icon/hd_hi",
+              "sizes": "128x128"
+            }],
+            "start_url": "/index.html",
+            "display": "standalone",
+            "note_taking": {
+              "new_note_url": "/new_note.html"
+            }
           }
         </pre>
       </section>

--- a/index.html
+++ b/index.html
@@ -149,10 +149,11 @@
         </h3>
         <p>
           The [=note_taking=] <code>new_note_url</code> member is a <a>URL</a>
-          [=manifest/within scope=] to open when the user wants to take a new
-          note using the web application (e.g., from an operating system
-          shortcut icon or keyboard shortcut). Defining this member indicates
-          that the web application is a note-taking application.
+          [=manifest/within scope=] of the manifest, to open when the user
+          wants to take a new note using the web application (e.g., from an
+          operating system shortcut icon or keyboard shortcut). Defining this
+          member indicates that the web application is a note-taking
+          application.
         </p>
       </section>
       <section class="informative">


### PR DESCRIPTION
Incubating a new field following discussions on https://github.com/w3c/manifest/issues/965
Intended for note-taking web apps to identify themselves as such, and to declare a URL to be loaded to take a new note.
Small enough that it probably doesn't need its own explainer.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/phoglenix/manifest-incubations/pull/7.html" title="Last updated on Mar 19, 2021, 5:36 AM UTC (d2d7f0a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/manifest-incubations/7/4714290...phoglenix:d2d7f0a.html" title="Last updated on Mar 19, 2021, 5:36 AM UTC (d2d7f0a)">Diff</a>