### PR TITLE
Add File Handling manifest member, parsing, LaunchQueue/LaunchParams

### DIFF
--- a/index.html
+++ b/index.html
@@ -565,10 +565,12 @@
         <p>
           A <dfn>file type</dfn> can be defined by a [=MIME type=] and/or
           [=file extension=]. A file belongs to a file type if the OS
-          determines it to have a [=MIME type=] and/or its name ends with a certain
-          [=file extension=]. A <dfn>file extension</dfn> is a string that
-          start with a "." and only contains <a data-cite="file-system-access#valid-suffix-code-points">valid suffix code points</a>. Additionally,
-          [=file extensions=] are limited to a length of 16 code points.
+          determines it to have a [=MIME type=] and/or its name ends with a
+          certain [=file extension=]. A <dfn>file extension</dfn> is a string
+          that start with a "." and only contains <a data-cite=
+          "file-system-access#valid-suffix-code-points">valid suffix code
+          points</a>. Additionally, [=file extensions=] are limited to a length
+          of 16 code points.
         </p>
         <section>
           <h3>
@@ -645,15 +647,15 @@
           </p>
           <p>
             In addition to complete [=MIME types=], <code>"*"</code> can be
-            used as the subtype of a [=MIME type=] to match, for example, all image
-            formats with <code>"image/*"</code> (that also apply to the
+            used as the subtype of a [=MIME type=] to match, for example, all
+            image formats with <code>"image/*"</code> (that also apply to the
             provided list of [=file extensions=]).
           </p>
           <aside class="note">
             For example, on Linux both the [=MIME type=] and [=file extension=]
             is used with the <code>xdg-mime</code> utility to specify that the
-            web application can open files with both the [=MIME type=] specified
-            and the specific file extension. On Windows, only [=file
+            web application can open files with both the [=MIME type=]
+            specified and the specific file extension. On Windows, only [=file
             extensions=] are used, so the [=MIME types=] are ignored.
           </aside>
         </section>
@@ -678,10 +680,19 @@
             a single launch event.
           </p>
           <aside class="note">
-            If an app is only meant to display one file per window or tab,
-            `"multiple-clients"` should be applied. Otherwise, one instance will
-            be launched and all opened files will be passed via the
-            {{LaunchParams/files}} array.
+            <p>
+              If an app is only meant to display one file per window or tab,
+              `"multiple-clients"` should be applied. Otherwise, one instance
+              will be launched and all opened files will be passed via the
+              {{LaunchParams/files}} array.
+            </p>
+            <p>
+              This field is subject to platform limitations. Windows never
+              launches an app with multiple files, but will launch a single app
+              multiple times with one file each. As such, this field has no
+              effect on Windows and all launches are effectively
+              `"mulitiple-clients"`.
+            </p>
           </aside>
         </section>
       </section>
@@ -737,12 +748,14 @@
               <li>If |extensions| [=list/contains=] strings that do not begin
               with the character `.`, [=iteration/continue=].
               </li>
-              <li>If |extensions| [=list/contains=] strings that are greater than 16 characters long, [=iteration/continue=].
+              <li>If |extensions| [=list/contains=] strings that are greater
+              than 16 characters long, [=iteration/continue=].
               </li>
               <li>Let |mime_type_parsed:mime type| be the result of running the
               steps of [=parse a mime type=] on |mime_type_string|.
               </li>
-              <li>If |mime_type_parsed:mime type| is failure, [=iteration/continue=].
+              <li>If |mime_type_parsed:mime type| is failure,
+              [=iteration/continue=].
               </li>
               <li>If |mime_type_parsed/type| is not listed as a top-level type
               in [[IANA-MEDIA-TYPES]], [=iteration/continue=].
@@ -754,7 +767,8 @@
           <li>If |accept:ordered map| is empty, return failure.
           </li>
           <li>Let |file_handler:ordered map| be |ordered map| «[ "action" →
-          |url|, "name" → |item|["name"], "launch_type" → |launch_type|, "accept" → |accept| ]».
+          |url|, "name" → |item|["name"], "launch_type" → |launch_type|,
+          "accept" → |accept| ]».
           </li>
           <li>
             <a data-cite="appmanifest#dfn-process-image-resources">Process
@@ -795,13 +809,15 @@
                           <li>If |filename| does not end in |extension|,
                           [=iteration/continue=].
                           </li>
-                          <li>If |launches|[|file_handler|] [=map/exists=], [=list/append=]
-                          |filename| to |launches|[|file_handler|].
+                          <li>If |launches|[|file_handler|] [=map/exists=],
+                          [=list/append=] |filename| to
+                          |launches|[|file_handler|].
                           </li>
-                          <li>Else, set |launches|[|file_handler|] to a [=list=]
-                          with the single element |filename|.
+                          <li>Else, set |launches|[|file_handler|] to a
+                          [=list=] with the single element |filename|.
                           </li>
-                          <li>[=iteration/Continue=] to next element of |files|.
+                          <li>[=iteration/Continue=] to next element of
+                          |files|.
                           </li>
                         </ol>
                       </li>
@@ -874,11 +890,12 @@
         <p>
           Depending on the operating system capabilities, the [=file handler=]
           could become a default handler of a given [=file type=] without the
-          explicit knowledge of the user, handling launches of a given file type automatically. To protect against possible mis-use,
-          [=user agents=] MAY require explicit user consent to begin with the
-          process to [=execute a file handler launch=]. If consent is sought,
-          the user agent SHOULD allow the user to specify that the decision is
-          permanent and if so specified SHOULD remove the web application's OS
+          explicit knowledge of the user, handling launches of a given file
+          type automatically. To protect against possible mis-use, [=user
+          agents=] MAY require explicit user consent to begin with the process
+          to [=execute a file handler launch=]. If consent is sought, the user
+          agent SHOULD allow the user to specify that the decision is permanent
+          and if so specified SHOULD remove the web application's OS
           registration as a file handling entity.
         </p>
       </section>
@@ -889,8 +906,9 @@
         <p>
           The name and icon of each file handler can be sensitive to privacy
           and security, as there isn't a specified way for the user to see and
-          confirm these. Due to this, [=user agents=] MAY choose to ignore these in
-          favor of alternative strings and icons or fall back on OS defaults.
+          confirm these. Due to this, [=user agents=] MAY choose to ignore
+          these in favor of alternative strings and icons or fall back on OS
+          defaults.
         </p>
       </section>
       <section class="informative">
@@ -1408,7 +1426,8 @@
           <li>If |params| is null, set |params| to a new {{LaunchParams}} with
           {{LaunchParams/targetURL}} set to [=manifest/start_url=].
           </li>
-          <li>Create a new top level browsing context and navigate it to |params.targetUrl|.
+          <li>Create a new top level browsing context and navigate it to
+          |params.targetUrl|.
           </li>
           <li>Append |params| to the [=unconsumed launch params=] of the
           launched document's {{Window.LaunchQueue}}.

--- a/index.html
+++ b/index.html
@@ -528,7 +528,7 @@
             item=] with |entry|, [=manifest/start_url=], [=manifest/scope=],
             and |manifest_url|.
             </li>
-            <li>If |file_handler| is failure, continue.
+            <li>If |file_handler| is failure, [=iteration/continue=].
             </li>
             <li>[=list/Append=] |file_handler| to |processedFileHandlers|.
             </li>
@@ -563,24 +563,13 @@
           with [=file type=] on the operating system.
         </p>
         <p>
-          A <dfn>file type</dfn> can be defined by a [=mime type=] and/or
+          A <dfn>file type</dfn> can be defined by a [=MIME type=] and/or
           [=file extension=]. A file belongs to a file type if the OS
-          determines it to have a mime type and/or its name ends with a certain
+          determines it to have a [=MIME type=] and/or its name ends with a certain
           [=file extension=]. A <dfn>file extension</dfn> is a string that
-          start with a "." and only contains [=valid suffix code points=]. A
-          <dfn>valid suffix code point</dfn> is a [=code point=] that is
-          [=ASCII alphanumeric=], U+002B (+), or U+002E (.). Additionally,
+          start with a "." and only contains <a data-cite="file-system-access#valid-suffix-code-points">valid suffix code points</a>. Additionally,
           [=file extensions=] are limited to a length of 16 code points.
         </p>
-        <aside class="note">
-          <p>
-            These code points were chosen to support most pre-existing file
-            formats. The vast majority of file extensions are purely
-            alphanumeric, but compound extensions (such as .tar.gz) and
-            extensions such as .c++ for C++ source code are also fairly common,
-            hence the inclusion of + and . as allowed code points.
-          </p>
-        </aside>
         <section>
           <h3>
             `action` member
@@ -603,7 +592,7 @@
           <p>
             The [=file handler=]'s <code><dfn data-dfn-for=
             "file handler">name</dfn></code> member is a <a>string</a> that
-            identifies the file type to the user. User agents MAY pass this
+            identifies the file type to the user. [=User agents=] MAY pass this
             information to the operating system during file handler
             registration.
           </p>
@@ -623,7 +612,7 @@
           </h3>
           <p>
             The <a>file handler</a>'s <code><dfn data-dfn-for=
-            "file handler">icons</dfn></code> member lists images that serve as
+            "file handler">icons</dfn></code> member lists icons that serve as
             graphical representations of a [=file type=] on a platform. User
             agents MAY pass this information to the operating system during
             file handler registration.
@@ -645,7 +634,7 @@
             mapping [=MIME types=] to a list of [=file extensions=].
           </p>
           <p>
-            User agents MUST enforce that the [=file handler/accept=] entry
+            [=User agents=] MUST enforce that the [=file handler/accept=] entry
             only applies to files that have a matching extension.
           </p>
           <p>
@@ -656,16 +645,16 @@
           </p>
           <p>
             In addition to complete [=MIME types=], <code>"*"</code> can be
-            used as the subtype of a MIME type to match, for example, all image
+            used as the subtype of a [=MIME type=] to match, for example, all image
             formats with <code>"image/*"</code> (that also apply to the
             provided list of [=file extensions=]).
           </p>
           <aside class="note">
-            For example, on Linux both the [=mime type=] and [=file extension=]
+            For example, on Linux both the [=MIME type=] and [=file extension=]
             is used with the <code>xdg-mime</code> utility to specify that the
-            web application can open files with both the mime type specified
+            web application can open files with both the [=MIME type=] specified
             and the specific file extension. On Windows, only [=file
-            extensions=] are used, so the [=mime types=] are ignored.
+            extensions=] are used, so the [=MIME types=] are ignored.
           </aside>
         </section>
         <section>
@@ -676,21 +665,21 @@
             The [=file handler=]'s <code><dfn data-dfn-for=
             "file handler">launch_type</dfn></code> member is a <a>string</a>
             that determines how the app is launched for files routed to this
-            handler. The possible values are "single-client" and
-            "multiple-clients". If not provided, it defaults to
-            "single-client".
+            handler. The possible values are `"single-client"` and
+            `"multiple-clients"`. If not provided, it defaults to
+            `"single-client"`.
           </p>
           <p>
             When a [=file handler=] is determined to match a set of files, the
             [=file handler/launch_type=] will control whether the app is
-            launched once for each file ("multiple-clients"), or one time for
-            all files ("single-client"). See {{LaunchParams/files}}. The user
-            agent MUST not coalesce files from different [=file handlers=] into
+            launched once for each file (`"multiple-clients"`), or one time for
+            all files (`"single-client"`). See {{LaunchParams/files}}. The user
+            agent MUST NOT coalesce files from different [=file handlers=] into
             a single launch event.
           </p>
           <aside class="note">
             If an app is only meant to display one file per window or tab,
-            "multiple-clients" should be applied. Otherwise, one instance will
+            `"multiple-clients"` should be applied. Otherwise, one instance will
             be launched and all opened files will be passed via the
             {{LaunchParams/files}} array.
           </aside>
@@ -706,7 +695,7 @@
           [=URL=] |manifest URL:URL|:
         </p>
         <ol class="algorithm">
-          <li>Return failure if any of the following are true:
+          <li>Return failure if any of the following is true:
             <ul>
               <li>|item|["action"] doesn't [=map/exist=] or is not a
               [=string=].
@@ -738,23 +727,25 @@
           <li>[=map/for each=] |mime_type_string:string| → |extensions| of
           |item|["accept"]
             <ol>
-              <li>If |extensions| is not a [=list=], continue.
+              <li>If |extensions| is not a [=list=], [=iteration/continue=].
               </li>
-              <li>If |extensions| is [=list/empty=], continue.
+              <li>If |extensions| is [=list/empty=], [=iteration/continue=].
               </li>
               <li>If |extensions| [=list/contains=] items that are not
-              [=string=]s, continue.
+              [=string=]s, [=iteration/continue=].
               </li>
               <li>If |extensions| [=list/contains=] strings that do not begin
-              with the character `.`, continue.
+              with the character `.`, [=iteration/continue=].
+              </li>
+              <li>If |extensions| [=list/contains=] strings that are greater than 16 characters long, [=iteration/continue=].
               </li>
               <li>Let |mime_type_parsed:mime type| be the result of running the
               steps of [=parse a mime type=] on |mime_type_string|.
               </li>
-              <li>If |mime_type_parsed:mime type| is failure, continue.
+              <li>If |mime_type_parsed:mime type| is failure, [=iteration/continue=].
               </li>
               <li>If |mime_type_parsed/type| is not listed as a top-level type
-              in in [[IANA-MEDIA-TYPES]], continue.
+              in [[IANA-MEDIA-TYPES]], [=iteration/continue=].
               </li>
               <li>Set |accept|[|mime_type_string|] to |extensions|.
               </li>
@@ -763,8 +754,7 @@
           <li>If |accept:ordered map| is empty, return failure.
           </li>
           <li>Let |file_handler:ordered map| be |ordered map| «[ "action" →
-          |url|, "name" → |item|["name"], "launch_type" → |launch_type|,
-          "launch_type" "accept" → |accept| ]».
+          |url|, "name" → |item|["name"], "launch_type" → |launch_type|, "accept" → |accept| ]».
           </li>
           <li>
             <a data-cite="appmanifest#dfn-process-image-resources">Process
@@ -795,23 +785,23 @@
           <li>[=list/for each=] |filename:string| of |files|
             <ol>
               <li>[=list/for each=] |file_handler:ordered_map| of
-              |file_handlers:list|
+              |file_handlers:list|:
                 <ol>
                   <li>[=map/for each=] |mime_type_string:string| →
                   |extensions:list| of |file_handler|["accept"]
                     <ol>
-                      <li>[=list/for each=] |extension:string| of |extensions|
+                      <li>[=list/for each=] |extension:string| of |extensions|:
                         <ol>
                           <li>If |filename| does not end in |extension|,
-                          continue.
+                          [=iteration/continue=].
                           </li>
-                          <li>If |launches|[|file_handler|] exists, append
+                          <li>If |launches|[|file_handler|] [=map/exists=], [=list/append=]
                           |filename| to |launches|[|file_handler|].
                           </li>
-                          <li>Else, set |launches|[|file_handler|] to a list
+                          <li>Else, set |launches|[|file_handler|] to a [=list=]
                           with the single element |filename|.
                           </li>
-                          <li>Continue to next element of |files|.
+                          <li>[=iteration/Continue=] to next element of |files|.
                           </li>
                         </ol>
                       </li>
@@ -883,10 +873,9 @@
         </h3>
         <p>
           Depending on the operating system capabilities, the [=file handler=]
-          could become a 'default' handler (e.g. handling launches of a given
-          file type automatically) of a given [=file type=] without the
-          explicit knowledge of the user. To protect against possible mis-use,
-          user agents MAY require explicit user consent to begin with the
+          could become a default handler of a given [=file type=] without the
+          explicit knowledge of the user, handling launches of a given file type automatically. To protect against possible mis-use,
+          [=user agents=] MAY require explicit user consent to begin with the
           process to [=execute a file handler launch=]. If consent is sought,
           the user agent SHOULD allow the user to specify that the decision is
           permanent and if so specified SHOULD remove the web application's OS
@@ -900,7 +889,7 @@
         <p>
           The name and icon of each file handler can be sensitive to privacy
           and security, as there isn't a specified way for the user to see and
-          confirm these. Due to this, user agents MAY choose to ignore these in
+          confirm these. Due to this, [=user agents=] MAY choose to ignore these in
           favor of alternative strings and icons or fall back on OS defaults.
         </p>
       </section>
@@ -938,6 +927,7 @@
                       ".grafr", ".graf"
                     ]
                   },
+                  launch_type: "multiple-clients",
                   "icons": [
                     {
                       "src": "/grafr-file.png",
@@ -1396,11 +1386,11 @@
             <li>[=list/For each=] |launch_params:LaunchParams| of [=unconsumed
             launch params=]:
               <ol>
-                <li>Call |consumer| with |launch_params|.
+                <li>Invoke |consumer| with |launch_params|.
                 </li>
               </ol>
             </li>
-            <li>Set [=unconsumed launch params=] to the empty list.
+            <li>Set [=unconsumed launch params=] to the empty [=list=].
             </li>
           </ol>
         </section>
@@ -1426,7 +1416,7 @@
               <li>[=list/For each=] |launch_params:LaunchParams| of
               [=unconsumed launch params=]:
                 <ol>
-                  <li>Call |consumer| with |launch_params|.
+                  <li>Invoke |consumer| with |launch_params|.
                   </li>
                 </ol>
               </li>

--- a/index.html
+++ b/index.html
@@ -673,11 +673,12 @@
           </p>
           <p>
             When a [=file handler=] is determined to match a set of files, the
-            [=file handler/launch_type=] will control whether the app is
-            launched once for each file (`"multiple-clients"`), or one time for
-            all files (`"single-client"`). See {{LaunchParams/files}}. The user
-            agent MUST NOT coalesce files from different [=file handlers=] into
-            a single launch event.
+            [=user agent=] SHOULD use [=file handler/launch_type=] to control
+            whether the app is launched once for each file
+            (`"multiple-clients"`), or one time for all files
+            (`"single-client"`). See {{LaunchParams/files}}. The user agent
+            MUST NOT coalesce files from different [=file handlers=] into a
+            single launch event.
           </p>
           <aside class="note">
             <p>
@@ -691,7 +692,7 @@
               launches an app with multiple files, but will launch a single app
               multiple times with one file each. As such, this field has no
               effect on Windows and all launches are effectively
-              `"mulitiple-clients"`.
+              `"multiple-clients"`.
             </p>
           </aside>
         </section>

--- a/index.html
+++ b/index.html
@@ -24,7 +24,7 @@
       };
     </script>
   </head>
-  <body>
+  <body data-cite="MIMESNIFF file-system-access appmanifest">
     <section id="abstract">
       <p>
         Feature specifications for <a href=
@@ -495,6 +495,462 @@
         </p>
       </section>
     </section>
+    <section>
+      <h3>
+        `file_handlers` member
+      </h3>
+      <p>
+        The [=manifest's=] <code><dfn data-export="" data-dfn-for=
+        "manifest">file_handlers</dfn></code> member is a [=list=] that
+        provides instructions for how the app handles file-opening actions that
+        originate outside of the app itself.
+      </p>
+      <p>
+        The management, presentation, and selection of registered file-handling
+        applications is at the discretion of the operating system.
+      </p>
+      <p>
+        To <dfn class="lint-ignore">process the `file_handlers` member</dfn>,
+        given [=ordered map=] |json:ordered map|, [=ordered map=]
+        |manifest:ordered map|, [=URL=] |manifest_url:URL|:
+      </p>
+      <ol class="algorithm">
+        <li>Let |processedFileHandlers:list| be a new [=list=].
+        </li>
+        <li>Set |manifest|["file_handlers"] to |processedFileHandlers|.
+        </li>
+        <li>If |json|["file_handlers"] doesn't [=map/exist=] or
+        |json|["file_handlers"] is not a [=list=], return.
+        </li>
+        <li>[=list/For each=] |entry:ordered map| of |json|["file_handlers"]:
+          <ol>
+            <li>Let |file_handler:ordered map| be [=process a file handler
+            item=] with |entry|, [=manifest/start_url=], [=manifest/scope=],
+            and |manifest_url|.
+            </li>
+            <li>If |file_handler| is failure, continue.
+            </li>
+            <li>[=list/Append=] |file_handler| to |processedFileHandlers|.
+            </li>
+          </ol>
+        </li>
+      </ol>
+      <p>
+        On [=installation=], a user agent SHOULD run the process to [=register
+        file handlers=].
+      </p>
+      <section data-cite="file-system-access">
+        <h2>
+          File Handler Items
+        </h2>
+        <p>
+          Each <dfn data-local-lt="file handler">file handler</dfn> represents
+          a URL in the scope of the application that can handle launches with
+          [=file types=] it accepts. It has the following members:
+        </p>
+        <ul>
+          <li>[=file handler/action=]
+          </li>
+          <li>[=file handler/name=]
+          </li>
+          <li>[=file handler/accept=]
+          </li>
+          <li>[=file handler/icons=]
+          </li>
+        </ul>
+        <p>
+          A user agent can use these members to associate the web application
+          with [=file type=] on the operating system.
+        </p>
+        <p>
+          A <dfn>file type</dfn> can be defined by a [=mime type=] and/or
+          [=file extension=]. A file belongs to a file type if the OS
+          determines it to have a mime type and/or its name ends with a certain
+          [=file extension=]. A <dfn>file extension</dfn> is a string that
+          start with a "." and only contains [=valid suffix code points=]. A
+          <dfn>valid suffix code point</dfn> is a [=code point=] that is
+          [=ASCII alphanumeric=], U+002B (+), or U+002E (.). Additionally,
+          [=file extensions=] are limited to a length of 16 code points.
+        </p>
+        <aside class="note">
+          <p>
+            These code points were chosen to support most pre-existing file
+            formats. The vast majority of file extensions are purely
+            alphanumeric, but compound extensions (such as .tar.gz) and
+            extensions such as .c++ for C++ source code are also fairly common,
+            hence the inclusion of + and . as allowed code points.
+          </p>
+        </aside>
+        <section>
+          <h3>
+            `action` member
+          </h3>
+          <p>
+            The [=file handler=]'s <code><dfn data-dfn-for=
+            "file handler">action</dfn></code> member is a <a>string</a> that
+            represents a URL relative to the <a data-cite=
+            "appmanifest#dfn-manifest-url">manifest URL</a> that is
+            [=manifest/within scope=] of a <a data-cite=
+            "appmanifest#dfn-processed-manifest">processed manifest</a> . This
+            URL will be navigated to in the steps to [=execute a file handler
+            launch=].
+          </p>
+        </section>
+        <section>
+          <h3>
+            `name` member
+          </h3>
+          <p>
+            The [=file handler=]'s <code><dfn data-dfn-for=
+            "file handler">name</dfn></code> member is a <a>string</a> that
+            identifies the file type to the user. User agents MAY pass this
+            information to the operating system during file handler
+            registration.
+          </p>
+          <aside class="note">
+            <p>
+              The [=file handler/name=] is used to identify and describe the
+              file type in a human readable format, and is typically only
+              displayed in OS surfaces (such as a file browser) if the web app
+              has become the default handler for that file type. It's most
+              useful for custom file types.
+            </p>
+          </aside>
+        </section>
+        <section>
+          <h3>
+            `icons` member
+          </h3>
+          <p>
+            The <a>file handler</a>'s <code><dfn data-dfn-for=
+            "file handler">icons</dfn></code> member lists images that serve as
+            graphical representations of a [=file type=] on a platform. User
+            agents MAY pass this information to the operating system during
+            file handler registration.
+          </p>
+          <aside class="note">
+            Semantically, the [=file handler/icons=] are used to convey the
+            file type itself and also the app. As with [=file handler/name=],
+            this is typically only displayed when the app has become the
+            default handler for a file type.
+          </aside>
+        </section>
+        <section>
+          <h3>
+            `accept` member
+          </h3>
+          <p>
+            The [=file handler=]'s <code><dfn data-dfn-for=
+            "file handler">accept</dfn></code> member is a <a>dictionary</a>
+            mapping [=MIME types=] to a list of [=file extensions=].
+          </p>
+          <p>
+            User agents MUST enforce that the [=file handler/accept=] entry
+            only applies to files that have a matching extension.
+          </p>
+          <p>
+            In order to [=register file handlers=], some operating systems
+            require [=MIME types=] and some require [=file extensions=]. Thus
+            the manifest MUST always provide both for each [=file
+            handler/accept=] entry.
+          </p>
+          <p>
+            In addition to complete [=MIME types=], <code>"*"</code> can be
+            used as the subtype of a MIME type to match, for example, all image
+            formats with <code>"image/*"</code> (that also apply to the
+            provided list of [=file extensions=]).
+          </p>
+          <aside class="note">
+            For example, on Linux both the [=mime type=] and [=file extension=]
+            is used with the <code>xdg-mime</code> utility to specify that the
+            web application can open files with both the mime type specified
+            and the specific file extension. On Windows, only [=file
+            extensions=] are used, so the [=mime types=] are ignored.
+          </aside>
+        </section>
+        <section>
+          <h3>
+            `launch_type` member
+          </h3>
+          <p>
+            The [=file handler=]'s <code><dfn data-dfn-for=
+            "file handler">launch_type</dfn></code> member is a <a>string</a>
+            that determines how the app is launched for files routed to this
+            handler. The possible values are "single-client" and
+            "multiple-clients". If not provided, it defaults to
+            "single-client".
+          </p>
+          <p>
+            When a [=file handler=] is determined to match a set of files, the
+            [=file handler/launch_type=] will control whether the app is
+            launched once for each file ("multiple-clients"), or one time for
+            all files ("single-client"). See {{LaunchParams/files}}. The user
+            agent MUST not coalesce files from different [=file handlers=] into
+            a single launch event.
+          </p>
+          <aside class="note">
+            If an app is only meant to display one file per window or tab,
+            "multiple-clients" should be applied. Otherwise, one instance will
+            be launched and all opened files will be passed via the
+            {{LaunchParams/files}} array.
+          </aside>
+        </section>
+      </section>
+      <section>
+        <h2>
+          Processing file handler items
+        </h2>
+        <p>
+          To <dfn>process a file handler item</dfn>, given [=ordered map=]
+          |item:ordered map|, [=URL=] |start_url:URL|, [=URL=] |scope:URL|, and
+          [=URL=] |manifest URL:URL|:
+        </p>
+        <ol class="algorithm">
+          <li>Return failure if any of the following are true:
+            <ul>
+              <li>|item|["action"] doesn't [=map/exist=] or is not a
+              [=string=].
+              </li>
+              <li>|item|["accept"] doesn't [=map/exist=].
+              </li>
+              <li>|item|["accept"] is not a [=dictionary=].
+              </li>
+              <li>|item|["accept"] [=map/is empty=].
+              </li>
+            </ul>
+          </li>
+          <li>Let |url:URL| be the result of [=URL Parser|parsing=]
+          |item|["action"] with |start_url URL| as the base URL.
+          </li>
+          <li>If |url| is failure, return failure.
+          </li>
+          <li>If |url| is not [=manifest/within scope=] of |scope|, return
+          failure.
+          </li>
+          <li>Let |launch_type:string| be a new [=string=] initialized to
+          "single-client".
+          </li>
+          <li>If |item|["launch_type"] [=map/exists=] and is
+          "multiple-clients", set |launch_type| to |item|["launch_type"].
+          </li>
+          <li>Let |accept:ordered map| be a new [=ordered map=].
+          </li>
+          <li>[=map/for each=] |mime_type_string:string| → |extensions| of
+          |item|["accept"]
+            <ol>
+              <li>If |extensions| is not a [=list=], continue.
+              </li>
+              <li>If |extensions| is [=list/empty=], continue.
+              </li>
+              <li>If |extensions| [=list/contains=] items that are not
+              [=string=]s, continue.
+              </li>
+              <li>If |extensions| [=list/contains=] strings that do not begin
+              with the character `.`, continue.
+              </li>
+              <li>Let |mime_type_parsed:mime type| be the result of running the
+              steps of [=parse a mime type=] on |mime_type_string|.
+              </li>
+              <li>If |mime_type_parsed:mime type| is failure, continue.
+              </li>
+              <li>If |mime_type_parsed/type| is not listed as a top-level type
+              in in [[IANA-MEDIA-TYPES]], continue.
+              </li>
+              <li>Set |accept|[|mime_type_string|] to |extensions|.
+              </li>
+            </ol>
+          </li>
+          <li>If |accept:ordered map| is empty, return failure.
+          </li>
+          <li>Let |file_handler:ordered map| be |ordered map| «[ "action" →
+          |url|, "name" → |item|["name"], "launch_type" → |launch_type|,
+          "launch_type" "accept" → |accept| ]».
+          </li>
+          <li>
+            <a data-cite="appmanifest#dfn-process-image-resources">Process
+            image resources</a> passing |item|["icons"], |file_handler|,
+            |manifest URL|, and "icons".
+          </li>
+          <li>Return |file_handler|.
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h2>
+          Execute a file handler launch
+        </h2>
+        <p>
+          The steps to <dfn>execute a file handler launch</dfn> are given by
+          the following algorithm. The algorithm takes [=list=] |files:list|
+          and a [=ordered map=] |manifest:ordered_map| which holds results from
+          [=processing a manifest=].
+        </p>
+        <ol class="algorithm">
+          <li>Let |file_handlers:list| be |manifest|["file_handlers"].
+          </li>
+          <li>If |file_handlers:list| is null, return.
+          </li>
+          <li>Let |launches:ordered map| be an [=ordered map=].
+          </li>
+          <li>[=list/for each=] |filename:string| of |files|
+            <ol>
+              <li>[=list/for each=] |file_handler:ordered_map| of
+              |file_handlers:list|
+                <ol>
+                  <li>[=map/for each=] |mime_type_string:string| →
+                  |extensions:list| of |file_handler|["accept"]
+                    <ol>
+                      <li>[=list/for each=] |extension:string| of |extensions|
+                        <ol>
+                          <li>If |filename| does not end in |extension|,
+                          continue.
+                          </li>
+                          <li>If |launches|[|file_handler|] exists, append
+                          |filename| to |launches|[|file_handler|].
+                          </li>
+                          <li>Else, set |launches|[|file_handler|] to a list
+                          with the single element |filename|.
+                          </li>
+                          <li>Continue to next element of |files|.
+                          </li>
+                        </ol>
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+          <li>[=map/for each=] |file_handler| → |files:list| of |launches|
+            <ol>
+              <li>If |file_handler|["launch_type"] is equal to
+              "multiple-clients"
+                <ol>
+                  <li>[=list/for each=] |file| of |files|
+                    <ol>
+                      <li>Let |params:LaunchParams| be a new {{LaunchParams}}
+                      with {{LaunchParams/files}} set to a {{FrozenArray}} with
+                      a single element that is a {{FileSystemHandle}}
+                      corresponding to |file|.
+                      </li>
+                      <li>[=launch a web app=] with |params|.
+                      </li>
+                    </ol>
+                  </li>
+                </ol>
+              </li>
+              <li>Else,
+                <ol>
+                  <li>Let |params:LaunchParams| be a new {{LaunchParams}} with
+                  {{LaunchParams/files}} set to a {{FrozenArray}} of
+                  {{FileSystemHandle}}s that correspond to the file paths named
+                  by |files|.
+                  </li>
+                  <li>[=launch a web app=] with |params|.
+                  </li>
+                </ol>
+              </li>
+            </ol>
+          </li>
+        </ol>
+      </section>
+      <section>
+        <h3>
+          Registering file handlers
+        </h3>
+        <p>
+          A user agent SHOULD <dfn>register file handlers</dfn> with the host
+          operating system, consistent with:
+        </p>
+        <ul>
+          <li>The app is exposed in appropriate OS surfaces such as the native
+          file browser and other surfaces that display lists of apps that can
+          handle a given file or file type.
+          </li>
+          <li>The app is a candidate for becoming the system's default handler
+          for associated file types.
+          </li>
+        </ul>
+        <p>
+          A user agent MAY truncate the total set of [=file extensions=] to
+          preserve functionality and prevent abuse. A user agent MAY prevent
+          associations with certain filetypes.
+        </p>
+      </section>
+      <section>
+        <h3>
+          Privacy consideration: Default file handler.
+        </h3>
+        <p>
+          Depending on the operating system capabilities, the [=file handler=]
+          could become a 'default' handler (e.g. handling launches of a given
+          file type automatically) of a given [=file type=] without the
+          explicit knowledge of the user. To protect against possible mis-use,
+          user agents MAY require explicit user consent to begin with the
+          process to [=execute a file handler launch=]. If consent is sought,
+          the user agent SHOULD allow the user to specify that the decision is
+          permanent and if so specified SHOULD remove the web application's OS
+          registration as a file handling entity.
+        </p>
+      </section>
+      <section>
+        <h3>
+          Privacy consideration: Name and icon.
+        </h3>
+        <p>
+          The name and icon of each file handler can be sensitive to privacy
+          and security, as there isn't a specified way for the user to see and
+          confirm these. Due to this, user agents MAY choose to ignore these in
+          favor of alternative strings and icons or fall back on OS defaults.
+        </p>
+      </section>
+      <section class="informative">
+        <h3>
+          Example manifest with file handlers
+        </h3>
+        <p>
+          In the following example, the web application has 3 different file
+          handlers.
+        </p>
+        <aside class="example">
+          <pre class="json">
+            {
+              "name": "Grafr",
+              "file_handlers": [
+                {
+                  "action": "/open-csv",
+                  "accept": {
+                    "text/csv": [ ".csv" ],
+                    "text/plain": [ ".txt" ]
+                  }
+                },
+                {
+                  "action": "/open-svg",
+                  "accept": {
+                    "image/svg+xml": [ ".svg" ]
+                  }
+                },
+                {
+                  "action": "/open-grafr",
+                  "name": "Grafr graph",
+                  "accept": {
+                    "application/vnd.grafr-graph": [
+                      ".grafr", ".graf"
+                    ]
+                  },
+                  "icons": [
+                    {
+                      "src": "/grafr-file.png",
+                      "sizes": "144x144"
+                    }
+                  ]
+                }
+              ]
+            }
+          </pre>
+        </aside>
+      </section>
+    </section>
     <section data-cite="DOM">
       <h2>
         Installation prompts
@@ -870,6 +1326,115 @@
             "event">beforeinstallprompt</dfn>" events.
           </p>
         </section>
+      </section>
+    </section>
+    <section data-cite="file-system-access permissions">
+      <h2>
+        Launch queue and launch params
+      </h2>
+      <section data-dfn-for="LaunchParams">
+        <h3>
+          <dfn>LaunchParams</dfn> interface
+        </h3>
+        <pre class="idl">
+          [Exposed=Window] interface LaunchParams {
+            readonly attribute DOMString? targetURL;
+            readonly attribute FrozenArray&lt;FileSystemHandle&gt; files;
+          };
+        </pre>
+        <p>
+          {{LaunchParams/targetURL}} represents the [=URL=] of the launch which
+          MUST be [=manifest/within scope=] of the application.
+        </p>
+        <p>
+          For every |file handle:FileSystemHandle| in {{LaunchParams/files}},
+          querying the file system permission with
+          {{FileSystemPermissionDescriptor/mode}} set to
+          {{FileSystemPermissionMode/"readwrite"}} MUST return
+          {{PermissionState/"granted"}}.
+        </p>
+      </section>
+      <section data-dfn-for="LaunchConsumer">
+        <h3>
+          <dfn>LaunchConsumer</dfn> function
+        </h3>
+        <pre class="idl">
+          callback LaunchConsumer = any (LaunchParams params);
+        </pre>
+      </section>
+      <section data-dfn-for="LaunchQueue">
+        <h3>
+          <dfn>LaunchQueue</dfn> interface
+        </h3>
+        <pre class="idl">
+          partial interface Window {
+            readonly attribute LaunchQueue launchQueue;
+          };
+
+          [Exposed=Window] interface LaunchQueue {
+            undefined setConsumer(LaunchConsumer consumer);
+          };
+        </pre>
+        <p>
+          {{LaunchQueue}} has an <dfn>unconsumed launch params</dfn> which is a
+          [=list=] of {{LaunchParams}} that is initially empty.
+        </p>
+        <p>
+          {{LaunchQueue}} has an <dfn>assigned launch consumer</dfn> which is
+          initially null.
+        </p>
+        <section>
+          <h2>
+            <dfn>setConsumer</dfn> method
+          </h2>
+          <p>
+            The {{LaunchQueue/setConsumer(consumer)}} method steps are:
+          </p>
+          <ol class="algorithm">
+            <li>Set the [=assigned launch consumer=] to |consumer|.
+            </li>
+            <li>[=list/For each=] |launch_params:LaunchParams| of [=unconsumed
+            launch params=]:
+              <ol>
+                <li>Call |consumer| with |launch_params|.
+                </li>
+              </ol>
+            </li>
+            <li>Set [=unconsumed launch params=] to the empty list.
+            </li>
+          </ol>
+        </section>
+      </section>
+      <section>
+        <h3>
+          Handling Web App Launches
+        </h3>
+        <p>
+          The steps to <dfn>launch a web app</dfn> are given by the following
+          algorithm. The algorithm takes {{LaunchParams}}
+          |params:LaunchParams|.
+        </p>
+        <ol class="algorithm">
+          <li>If |params| is null, set |params| to a new {{LaunchParams}} with
+          {{LaunchParams/targetURL}} set to [=manifest/start_url=].
+          </li>
+          <li>Append |params| to the [=unconsumed launch params=] of the
+          launched document's {{Window.LaunchQueue}}.
+          </li>
+          <li>If the [=assigned launch consumer=] |consumer| is set:
+            <ol>
+              <li>[=list/For each=] |launch_params:LaunchParams| of
+              [=unconsumed launch params=]:
+                <ol>
+                  <li>Call |consumer| with |launch_params|.
+                  </li>
+                </ol>
+              </li>
+              <li>Set [=unconsumed launch params=] to the empty list.
+              </li>
+            </ol>
+          </li>
+        </ol>
       </section>
     </section>
     <section id="conformance"></section>

--- a/index.html
+++ b/index.html
@@ -946,7 +946,7 @@
                       ".grafr", ".graf"
                     ]
                   },
-                  launch_type: "multiple-clients",
+                  "launch_type": "multiple-clients",
                   "icons": [
                     {
                       "src": "/grafr-file.png",

--- a/index.html
+++ b/index.html
@@ -18,13 +18,13 @@
         github: "WICG/manifest-incubations",
         shortName: "manifest-incubations",
         xref: {
-          specs: ["appmanifest", "dom"],
+          specs: ["appmanifest", "dom", "mimesniff", "file-system-access"],
           profile: "web-platform",
         },
       };
     </script>
   </head>
-  <body data-cite="MIMESNIFF file-system-access appmanifest">
+  <body>
     <section id="abstract">
       <p>
         Feature specifications for <a href=

--- a/index.html
+++ b/index.html
@@ -709,7 +709,7 @@
             </ul>
           </li>
           <li>Let |url:URL| be the result of [=URL Parser|parsing=]
-          |item|["action"] with |start_url URL| as the base URL.
+          |item|["action"] with |manifest_url URL| as the base URL.
           </li>
           <li>If |url| is failure, return failure.
           </li>
@@ -1407,6 +1407,8 @@
         <ol class="algorithm">
           <li>If |params| is null, set |params| to a new {{LaunchParams}} with
           {{LaunchParams/targetURL}} set to [=manifest/start_url=].
+          </li>
+          <li>Create a new top level browsing context and navigate it to |params.targetUrl|.
           </li>
           <li>Append |params| to the [=unconsumed launch params=] of the
           launched document's {{Window.LaunchQueue}}.


### PR DESCRIPTION
Add description of manifest member file_handlers as well as a rough sketch of LaunchQueue and LaunchParams.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/evanstade/manifest-incubations/pull/51.html" title="Last updated on Apr 14, 2022, 4:34 PM UTC (1c0642a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/manifest-incubations/51/e3db473...evanstade:1c0642a.html" title="Last updated on Apr 14, 2022, 4:34 PM UTC (1c0642a)">Diff</a>