### PR TITLE
Rewrite web app launch procedures in terms of the web-app-launch spec algorithm

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@
             "dom",
             "file-system-access",
             "mimesniff",
-            "web-app-launch",
+            "web-app-launch"
             "window-controls-overlay"
           ],
           profile: "web-platform",
@@ -476,13 +476,13 @@
             <var>protocol_handler</var> having [=manifest=] <var>manifest</var>
             is invoked, it goes through the same steps used to [=invoke a
             protocol handler=] where the user agent, instead of [=navigating=]
-            to |resultURL|, SHOULD [=launch a web application=] passing
-            <var>manifest</var> and |resultURL|.
+            to <var>resultURL</var>, SHOULD [=launch a web application=]
+            passing <var>manifest</var> and <var>resultURL</var>.
           </p>
           <p class="issue">
             This should not invoke and alter [=invoke a protocol handler=] in
-            this way. The computation of |resultURL| should be extracted out
-            into a separate algorithm for general use.
+            this way. The computation of <var>resultURL</var> should be
+            extracted out into a separate algorithm for general use.
           </p>
         </section>
       </section>
@@ -860,7 +860,7 @@
                       a single element that is a {{FileSystemHandle}}
                       corresponding to |file|.
                       </li>
-                      <li>[=Launch a web application with handling=] passing
+                      <li><a data-cite="web-app-launch#dfn-launch-a-web-application-with-handling">Launch a web application with handling</a> passing
                       |manifest| and |params|.
                       </li>
                     </ol>
@@ -874,7 +874,7 @@
                   {{FileSystemHandle}}s that correspond to the file paths named
                   by |files|.
                   </li>
-                  <li>[=Launch a web application with handling=] passing
+                  <li><a data-cite="web-app-launch#dfn-launch-a-web-application-with-handling">Launch a web application with handling</a> passing
                   |manifest| and |params|.
                 </ol>
               </li>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,6 @@
             "dom",
             "file-system-access",
             "mimesniff",
-            "web-app-launch"
             "window-controls-overlay"
           ],
           profile: "web-platform",
@@ -855,12 +854,16 @@
                 <ol>
                   <li>[=list/for each=] |file| of |files|
                     <ol>
-                      <li>Let |params:LaunchParams| be a new {{LaunchParams}}
-                      with {{LaunchParams/files}} set to a {{FrozenArray}} with
-                      a single element that is a {{FileSystemHandle}}
-                      corresponding to |file|.
+
+                      <li>Let |params:LaunchParams| be a new
+                      <a href="https://wicg.github.io/web-app-launch/#dom-launchparams">
+                      LaunchParams</a> with
+                      <a href="https://wicg.github.io/web-app-launch/#dom-launchparams-files">
+                      files</a> set to a {{FrozenArray}} with a single element
+                      that is a {{FileSystemHandle}} corresponding to |file|.
                       </li>
-                      <li><a data-cite="web-app-launch#dfn-launch-a-web-application-with-handling">Launch a web application with handling</a> passing
+                      <li><a href="https://wicg.github.io/web-app-launch/#dfn-launching-a-web-application-with-handling">
+                      Launch a web application with handling</a> passing
                       |manifest| and |params|.
                       </li>
                     </ol>
@@ -869,13 +872,17 @@
               </li>
               <li>Else,
                 <ol>
-                  <li>Let |params:LaunchParams| be a new {{LaunchParams}} with
-                  {{LaunchParams/files}} set to a {{FrozenArray}} of
-                  {{FileSystemHandle}}s that correspond to the file paths named
-                  by |files|.
+                  <li>Let |params:LaunchParams| be a new
+                  <a href="https://wicg.github.io/web-app-launch/#dom-launchparams">
+                  LaunchParams</a> with
+                  <a href="https://wicg.github.io/web-app-launch/#dom-launchparams-files">
+                  files</a> set to a {{FrozenArray}} of {{FileSystemHandle}}s
+                  that correspond to the file paths named by |files|.
                   </li>
-                  <li><a data-cite="web-app-launch#dfn-launch-a-web-application-with-handling">Launch a web application with handling</a> passing
-                  |manifest| and |params|.
+                  <li><a href="https://wicg.github.io/web-app-launch/#dfn-launching-a-web-application-with-handling">
+                  Launch a web application with handling</a> passing |manifest|
+                  and |params|.
+                  </li>
                 </ol>
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -282,8 +282,9 @@
           <li>If the type of |manifest|["note_taking"]["new_note_url"] is not
           [=URL=], return.
           </li>
-          <li>Run the steps to [=launch a web app with handling=] passing
-          |manifest| and |manifest|["note_taking"]["new_note_url"].
+          <li>Run the steps to [=launch a web application=] setting |manifest|
+          to |manifest| and |target URL| to
+          |manifest|["note_taking"]["new_note_url"].
           </li>
         </ol>
       </section>
@@ -474,10 +475,14 @@
             When a <a>protocol handler description</a>
             <var>protocol_handler</var> having [=manifest=] <var>manifest</var>
             is invoked, it goes through the same steps used to [=invoke a
-            protocol handler=] defined in [=HTML=] where the user agent,
-            instead of [=navigating=] to [=url=], SHOULD
-            [=launch a web app with handling=] passing <var>manifest</var> and
-            [=url=].
+            protocol handler=] where the user agent, instead of [=navigating=]
+            to |resultURL|, SHOULD [=launch a web application=] passing
+            <var>manifest</var> and |resultURL|.
+          </p>
+          <p class="issue">
+            This should not invoke and alter [=invoke a protocol handler=] in
+            this way. The computation of |resultURL| should be extracted out
+            into a separate algorithm for general use.
           </p>
         </section>
       </section>
@@ -855,8 +860,8 @@
                       a single element that is a {{FileSystemHandle}}
                       corresponding to |file|.
                       </li>
-                      <li>[=Launch a web app with handling=] passing |manifest|
-                      and |params|.
+                      <li>[=Launch a web application with handling=] passing
+                      |manifest| and |params|.
                       </li>
                     </ol>
                   </li>
@@ -869,8 +874,8 @@
                   {{FileSystemHandle}}s that correspond to the file paths named
                   by |files|.
                   </li>
-                  <li>[=Launch a web app with handling=] passing |manifest| and
-                  |params|.
+                  <li>[=Launch a web application with handling=] passing
+                  |manifest| and |params|.
                 </ol>
               </li>
             </ol>

--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
             "dom",
             "file-system-access",
             "mimesniff",
+            "web-app-launch",
             "window-controls-overlay"
           ],
           profile: "web-platform",
@@ -281,11 +282,8 @@
           <li>If the type of |manifest|["note_taking"]["new_note_url"] is not
           [=URL=], return.
           </li>
-          <li>Let |browsing context:Browsing Context| be the result of creating
-          a new [=top-level browsing context=].
-          </li>
-          <li>[=Navigate=] |browsing context| to resource
-          |manifest|["note_taking"]["new_note_url"].
+          <li>Run the steps to [=launch a web app with handling=] passing
+          |manifest| and |manifest|["note_taking"]["new_note_url"].
           </li>
         </ol>
       </section>
@@ -476,9 +474,10 @@
             When a <a>protocol handler description</a>
             <var>protocol_handler</var> having [=manifest=] <var>manifest</var>
             is invoked, it goes through the same steps used to [=invoke a
-            protocol handler=] defined in [=HTML=], where the user agent SHOULD
-            navigate to [=url=] and the appropriate browsing context is set to
-            a new top level browsing context.
+            protocol handler=] defined in [=HTML=] where the user agent,
+            instead of [=navigating=] to [=url=], SHOULD
+            [=launch a web app with handling=] passing <var>manifest</var> and
+            [=url=].
           </p>
         </section>
       </section>
@@ -856,7 +855,8 @@
                       a single element that is a {{FileSystemHandle}}
                       corresponding to |file|.
                       </li>
-                      <li>[=launch a web app=] with |params|.
+                      <li>[=Launch a web app with handling=] passing |manifest|
+                      and |params|.
                       </li>
                     </ol>
                   </li>
@@ -869,8 +869,8 @@
                   {{FileSystemHandle}}s that correspond to the file paths named
                   by |files|.
                   </li>
-                  <li>[=launch a web app=] with |params|.
-                  </li>
+                  <li>[=Launch a web app with handling=] passing |manifest| and
+                  |params|.
                 </ol>
               </li>
             </ol>
@@ -1356,118 +1356,6 @@
             "event">beforeinstallprompt</dfn>" events.
           </p>
         </section>
-      </section>
-    </section>
-    <section data-cite="file-system-access permissions">
-      <h2>
-        Launch queue and launch params
-      </h2>
-      <section data-dfn-for="LaunchParams">
-        <h3>
-          <dfn>LaunchParams</dfn> interface
-        </h3>
-        <pre class="idl">
-          [Exposed=Window] interface LaunchParams {
-            readonly attribute DOMString? targetURL;
-            readonly attribute FrozenArray&lt;FileSystemHandle&gt; files;
-          };
-        </pre>
-        <p>
-          {{LaunchParams/targetURL}} represents the [=URL=] of the launch which
-          MUST be [=manifest/within scope=] of the application.
-        </p>
-        <p>
-          For every |file handle:FileSystemHandle| in {{LaunchParams/files}},
-          querying the file system permission with
-          {{FileSystemPermissionDescriptor/mode}} set to
-          {{FileSystemPermissionMode/"readwrite"}} MUST return
-          {{PermissionState/"granted"}}.
-        </p>
-      </section>
-      <section data-dfn-for="LaunchConsumer">
-        <h3>
-          <dfn>LaunchConsumer</dfn> function
-        </h3>
-        <pre class="idl">
-          callback LaunchConsumer = any (LaunchParams params);
-        </pre>
-      </section>
-      <section data-dfn-for="LaunchQueue">
-        <h3>
-          <dfn>LaunchQueue</dfn> interface
-        </h3>
-        <pre class="idl">
-          partial interface Window {
-            readonly attribute LaunchQueue launchQueue;
-          };
-
-          [Exposed=Window] interface LaunchQueue {
-            undefined setConsumer(LaunchConsumer consumer);
-          };
-        </pre>
-        <p>
-          {{LaunchQueue}} has an <dfn>unconsumed launch params</dfn> which is a
-          [=list=] of {{LaunchParams}} that is initially empty.
-        </p>
-        <p>
-          {{LaunchQueue}} has an <dfn>assigned launch consumer</dfn> which is
-          initially null.
-        </p>
-        <section>
-          <h2>
-            <dfn>setConsumer</dfn> method
-          </h2>
-          <p>
-            The {{LaunchQueue/setConsumer(consumer)}} method steps are:
-          </p>
-          <ol class="algorithm">
-            <li>Set the [=assigned launch consumer=] to |consumer|.
-            </li>
-            <li>[=list/For each=] |launch_params:LaunchParams| of [=unconsumed
-            launch params=]:
-              <ol>
-                <li>Invoke |consumer| with |launch_params|.
-                </li>
-              </ol>
-            </li>
-            <li>Set [=unconsumed launch params=] to the empty [=list=].
-            </li>
-          </ol>
-        </section>
-      </section>
-      <section>
-        <h3>
-          Handling Web App Launches
-        </h3>
-        <p>
-          The steps to <dfn>launch a web app</dfn> are given by the following
-          algorithm. The algorithm takes {{LaunchParams}}
-          |params:LaunchParams|.
-        </p>
-        <ol class="algorithm">
-          <li>If |params| is null, set |params| to a new {{LaunchParams}} with
-          {{LaunchParams/targetURL}} set to [=manifest/start_url=].
-          </li>
-          <li>Create a new top level browsing context and navigate it to
-          |params.targetUrl|.
-          </li>
-          <li>Append |params| to the [=unconsumed launch params=] of the
-          launched document's {{Window.LaunchQueue}}.
-          </li>
-          <li>If the [=assigned launch consumer=] |consumer| is set:
-            <ol>
-              <li>[=list/For each=] |launch_params:LaunchParams| of
-              [=unconsumed launch params=]:
-                <ol>
-                  <li>Invoke |consumer| with |launch_params|.
-                  </li>
-                </ol>
-              </li>
-              <li>Set [=unconsumed launch params=] to the empty list.
-              </li>
-            </ol>
-          </li>
-        </ol>
       </section>
     </section>
     <section id="conformance"></section>


### PR DESCRIPTION
Fixes: https://github.com/WICG/web-app-launch/issues/67

This updates 3 launch sites in manifest-incubations (note taking, protocol handlers and file handlers) to make use of the [=launch a web application with handling=] algorithm being added by: https://github.com/WICG/web-app-launch/pull/79/files

Note that the removal of `Launch queue and launch params` from this spec is due to these concepts already existing in https://wicg.github.io/web-app-launch/#script-interfaces-to-app-launches.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/alancutter/manifest-incubations/pull/63.html" title="Last updated on Nov 9, 2022, 2:51 AM UTC (c07bf86)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/manifest-incubations/63/e63d465...alancutter:c07bf86.html" title="Last updated on Nov 9, 2022, 2:51 AM UTC (c07bf86)">Diff</a>