### PR TITLE
Clarify file_handlers.icons semantics

### DIFF
--- a/index.html
+++ b/index.html
@@ -720,13 +720,14 @@
             registration.
           </p>
           <aside class="note">
-            The [=file handler/icons=] member is expected to be an image that
-            represents all files that are associated with the handler. This
-            will typically appear like a document (e.g. a piece of paper) as
-            opposed to an application logo, but may include elements (such as
-            logos) that suggest which application the file is associated with.
-            As with [=file handler/name=], this is typically only displayed
-            when the app has become the default handler for a file type.
+            The [=file handler/icons=] member is expected to be an image (or
+            collection of images at different sizes) that represents all files
+            that are associated with the handler. This will typically appear
+            like a document (e.g. a piece of paper) as opposed to an
+            application logo, but may include elements (such as logos) that
+            suggest which application the file is associated with. As with
+            [=file handler/name=], this is typically only displayed when the
+            app has become the default handler for a file type.
           </aside>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -715,9 +715,9 @@
           <p>
             The <a>file handler</a>'s <code><dfn data-dfn-for=
             "file handler">icons</dfn></code> member lists icons that serve as
-            graphical representations of a [=file type=] on a platform. User
-            agents MAY pass this information to the operating system during
-            file handler registration.
+            graphical representations of a [=file type=]. User agents MAY pass
+            this information to the operating system during file handler
+            registration.
           </p>
           <aside class="note">
             Semantically, the [=file handler/icons=] are used to convey the

--- a/index.html
+++ b/index.html
@@ -720,10 +720,13 @@
             registration.
           </p>
           <aside class="note">
-            Semantically, the [=file handler/icons=] are used to convey the
-            file type itself and also the app. As with [=file handler/name=],
-            this is typically only displayed when the app has become the
-            default handler for a file type.
+            The [=file handler/icons=] member is expected to be an image that
+            represents all files that are associated with the handler. This
+            will typically appear like a document (e.g. a piece of paper) as
+            opposed to an application logo, but may include elements (such as
+            logos) that suggest which application the file is associated with.
+            As with [=file handler/name=], this is typically only displayed
+            when the app has become the default handler for a file type.
           </aside>
         </section>
         <section>

--- a/index.html
+++ b/index.html
@@ -724,7 +724,7 @@
             collection of images at different sizes) that represents all files
             that are associated with the handler. This will typically appear
             like a document (e.g. a piece of paper) as opposed to an
-            application logo, but may include elements (such as logos) that
+            application logo, but might include elements (such as logos) that
             suggest which application the file is associated with. As with
             [=file handler/name=], this is typically only displayed when the
             app has become the default handler for a file type.


### PR DESCRIPTION
Rewrote the note to clarify the purpose and intent of file handler icons.

This properly explains that file handler icons should represent the file type, not the application, but that it can include the application logo to imply which app will open the file.

Also makes a minor change to normative text (remove "on a platform").

Closes #86.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mgiuca/manifest-incubations/pull/87.html" title="Last updated on Jan 12, 2024, 2:53 AM UTC (008a322)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/manifest-incubations/87/47dbb35...mgiuca:008a322.html" title="Last updated on Jan 12, 2024, 2:53 AM UTC (008a322)">Diff</a>