### PR TITLE
Update scope_extensions-explainer.md

### DIFF
--- a/scope_extensions-explainer.md
+++ b/scope_extensions-explainer.md
@@ -38,13 +38,14 @@ associated origins.
    Example manifest located at `https://example.com/manifest.webmanifest`:
    ```json
    {
-     "id": "",
+     "id": "/",
      "name": "Example",
      "display": "standalone",
      "start_url": "/index.html",
      "scope_extensions": [
        {"origin": "*.example.com"},
        {"origin": "example.co.uk"},
+       {"origin": "*.example.co.uk"},
        {"origin": "*.example.co.uk"}
      ]
    }


### PR DESCRIPTION
Add a `/` to the id field.
 This is because the empty "" actually exits the algo early and make the id the start_url