### PR TITLE
Archive translations explainer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ Specification link: https://wicg.github.io/manifest-incubations/index.html
 # Explainers
 
  - [Scope Extensions for Web Apps](scope_extensions-explainer.md)
- - [Web App Translations](translations-explainer.md)
 
 # Background
 

--- a/archived/translations-explainer.md
+++ b/archived/translations-explainer.md
@@ -1,5 +1,9 @@
 # Web App Translations
 
+**This document is obsolete. The manifest editors have chosen to implement this using a different approach. You can track the progress in [w3c/manifest#1101](https://github.com/WICG/manifest-incubations/pull/103).**
+
+---
+
 Authors: [Aaron Gustafson](https://github.com/aarongustafson), Louise Brett (loubrett@google.com), Glen Robertson (glenrob@chromium.org)
 
 TODO: This explainer needs to be updated to match the [Web Manifest Overrides](https://github.com/w3c/manifest/issues/1045) proposal.


### PR DESCRIPTION
This is now picked up in https://github.com/w3c/manifest/pull/1101.