### PR TITLE
Scope extensions update to split "origin" and "site" type extensions

### DIFF
--- a/scope_extensions-explainer.md
+++ b/scope_extensions-explainer.md
@@ -1,38 +1,60 @@
 # Scope Extensions for Web Apps
 
-## Overview
+## Abstract
 
-This document describes a new `scope_extensions` manifest member that enables
-web apps to extend their
-[scope](https://www.w3.org/TR/appmanifest/#understanding-scope) to other
-origins.
+This document proposes a new `scope_extensions` [Web Application
+Manifest](https://www.w3.org/TR/appmanifest/) member that extends the concept of
+[app scope](https://www.w3.org/TR/appmanifest/#understanding-scope). User agents
+apply the manifest to documents that are [within
+scope](https://www.w3.org/TR/appmanifest/#dfn-within-scope) and often apply
+different UX treatments when visiting documents outside of scope. According to
+existing specification, the scope of an app can be made no broader than a single
+[web origin](https://datatracker.ietf.org/doc/rfc6454/). Apps that wish to
+define a scope spanning multiple origins could do so using the proposed
+`scope_extensions` member.
 
 ## Introduction
 
-A web application's content might originate from different scopes. Currently, if
-an installed web application navigates to a url that is out of the scope defined
-in the manifest file, a security UX will appear in the form of a bar to indicate
-to the user that they are outside of the defined scope of the application. 
-
-<!-- TODO link to spec language around out-of-scope UI -->
+In Chromium browsers, top-level app window navigation to an out-of-scope URL
+creates a notification bar - this notification bar informs the user that they
+have navigated outside of app scope or to a different origin altogether, and
+provides a control to return to the `start_url`. Other browser implementations
+may display similar behavior.
 
 <figure>
     <img src="images/out-of-scope-ux.png" width="600" alt="">
-    <figcaption>Installed web app window with out-of-scope UI</figcaption>
+    <figcaption>Example: installed web app window with out-of-scope bar UI</figcaption>
 </figure>
 
-The app in the image (`PWinter`) has navigated to a url out of its scope
-(`airhorner.com`). The white bar on top of the web app is providing information
-to the user about this change of scope. While this is a security feature, it can
-be the case that an application wants to extend its scope. For example, an
-application might host content that is located in one specific origin, and rely
-on a login page that is out of the scope of the application itself to access
-that content. In other cases, the same application might be associated to
-multiple Top Level Domains, that might respond to different locales
-(`app.com`, `app.co.uk`, `app.co.cr`, etc).
+The app window above has navigated to a url (`https://airhorner.com`) outside of
+its scope (`https://diek.us/pwinter/`). The white bar above the web contents
+informs the user of this difference. This feature aims to keep the user aware of
+the content's security context.
+
+A developer may intentionally want to include documents from different origins
+in app scope. In this case, the out-of-scope bar is not necessary and could
+confuse users. Furthermore, as app scope is used as the boundary for the
+application of manifest features such as `theme_color`, documents intended to be
+part of the app but are excluded from app scope are not presented in a
+consistent manner. 
+
+## Motivating use cases 
+
+* Multiple TLDs
+
+* Multiple subdomains (slack, zoom, etc)
+
+* Link capturing
+<!-- TODO -->
+
+For example, an application might host content that is located
+in one specific origin, and rely on a login page that is out of the scope of the
+application itself to access that content. In other cases, the same application
+might be associated to multiple Top Level Domains, that might respond to
+different locales (`app.com`, `app.co.uk`, `app.co.cr`, etc).
 
 
-## Use Cases / Goals
+## Goals
 
 - Allow sites that control multiple subdomains and top level domains to behave
   as one contiguous web app.\
@@ -41,27 +63,21 @@ multiple Top Level Domains, that might respond to different locales
 - Allow web apps to capture user navigations to sites they are affiliated with.\
   E.g. "News Aggregator App" capturing links navigations to examplenewssite.com.
 
+## Non-goals
 
-## Background
-
-Web app scope (defined by the `scope` field) is currently used for:
-1. Determining whether an app window's root document has left the app's scope
-   (possibly invoking window UI informing the user of this).
-1. Constraining URLs appearing in manifest members like `start_url`,
-   `file_handlers`, or `share_target`.
-
-The `scope_extensions` mechanism can expand all these behaviours to include
-other origins given agreement between the web app's primary origin and the
-associated origins.
-
+<!-- TODO -->
 
 ## Proposal
-To extend the app scope, a developer will need to modify the web app manifest, host
-one or more association files, and may also have to add a new response header with
-returned documents.
+
+`scope_extensions` works by ...
+<!-- TODO -->
 
 A new field `scope_extensions` in the manifest declares which origins or sites should
 join the app scope. 
+
+To extend the app scope, a developer will need to modify the web app manifest, host
+one or more association files, and may also have to add a new response header with
+returned documents.
 
 A two-way handshake between the app and the extension origin/site is established
 when the origin/site hosts a `.well-known/web-app-origin-association` file. This file
@@ -70,9 +86,11 @@ participate.
 
 <!-- TODO: Add graphic illustrating the 3 components. -->
 
-### Web app manifest
-Add a `scope_extensions` member to the web app manifest specifying a list of
-origins to include in the extended app scope. 
+### Manifest
+Use `scope_extensions` member in the web app manifest to declare origins in the
+the extended app scope. 
+
+<!-- TODO each origin has `scope` parameter as well. -->
 
 Example manifest located at `https://example.com/manifest.webmanifest`:
    ```json
@@ -241,6 +259,9 @@ app](images/scope-privacy-info.png)
 In the previous image, a user can always see which domain is serving content
 under the privacy menu. 
 
+## Alternatives considered
+
+<!-- TODO -->
 
 ## Related Proposals
 

--- a/scope_extensions-explainer.md
+++ b/scope_extensions-explainer.md
@@ -246,10 +246,11 @@ the following attack vector:
 
 ## Future work under consideration 
 
-1. More fine-grained scoping mechanisms such as include/exclude lists or [URL
-  patterns](https://wicg.github.io/urlpattern/). These mechanisms could be
-  reused in 3 difference places: in the association file, in `scope_extensions`
-  in the manifest, at the top level in the manifest.
+1. More [fine-grained scoping
+  mechanisms](https://github.com/w3c/manifest/issues/996) such as
+  include/exclude lists or [URL patterns](https://wicg.github.io/urlpattern/).
+  These mechanisms could be reused in 3 difference places: in the association
+  file, in `scope_extensions` in the manifest, at the top level in the manifest.
 
 1. Change the constraint on manifest URLs that are bound by scope (except for
   `start_url`) to instead be bound by the extended scope. Validation of the

--- a/scope_extensions-explainer.md
+++ b/scope_extensions-explainer.md
@@ -68,30 +68,36 @@ Example manifest located at `https://example.com/manifest.webmanifest`:
      "start_url": "/app/index.html",
      "scope": "/app",
      "scope_extensions": [
-       { "type": "registrable_domain", "value": "https://example.com" },
-       { "type": "registrable_domain", "value": "https://example.co.uk" },
+       { "type": "site", "value": "https://example.com" },
+       { "type": "site", "value": "https://example.co.uk" },
        { "type": "origin", "value": "https://helpcenter.example-help-center.com" }
      ]
    }
    ```
-In this example the "Example" app has a regular scope of
-`http://example.com/app` and is extending its app scope to the registrable
-domains of `https://example.com` and `https://example.co.uk`, as well as the
-single origin `https://helpcenter.example-help-center.com`. 
+The "Example" app has a regular scope of `http://example.com/app` and is
+extending its app scope to the sites `https://example.com`,
+`https://example.co.uk`, and the single origin 
+`https://helpcenter.example-help-center.com`. 
 
-Each object in `scope_extension` must contain both `type` and `value` string
-fields. The value of `type` must be one of `["origin" | "registrable_domain"]`.
-The `value` field must contain a valid URL. 
+Each object in `scope_extensions` must contain both `type` and `value` string
+fields. The value of `type` must be one of `["origin" | "site"]`. The `value`
+field must contain a valid URL. 
 
-| type   | Behavior |
+An `"origin"` extension adds that specific web origin to the app scope, while a
+`"site"` extension adds all origins that passes the same-site test with the
+specified host. Origins and sites have the option of filtering what resources
+are allowed to join the app scope by configuring filters in their 
+`.well-known/web-app-origin-association` file.
+
+<!-- TODO -->
+| Type   | Behavior |
 |--------|----------|
-| `origin` | The URL in `value` is converted to an [origin](https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple). The `/` path of that origin is added to the extended scope.|
-| `registrable_domain` | The URL in `value` is converted to a [registrable domain](https://url.spec.whatwg.org/#host-registrable-domain). The `/` paths of all sub-domain origins within the registrable domain are added to the extended scope.|
+| `origin` | The URL in `value` is converted to an [origin](https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple). All allowed paths of that origin is added to the extended scope.|
+| `site` | The URL in `value` is converted to a [host](https://url.spec.whatwg.org/#hosts-(domains-and-ip-addresses)). All allowed paths of all origins that pass the [same-site test](https://html.spec.whatwg.org/multipage/browsers.html#obtain-a-site) as the host are added to the extended scope.|
 
 This format allows for both backward and forward compatibility. For example, a
 new type of entry could filter the paths of an origin added to the extended
-scope. Entries with types are that not recognized by a user agent should be
-ignored.
+scope. Entries with types not recognized by a user agent should be ignored.
 
 ### Association file
  Specify a `web-app-origin-association` file that must be located at

--- a/scope_extensions-explainer.md
+++ b/scope_extensions-explainer.md
@@ -32,7 +32,8 @@ using the `scope_extensions` manifest field detailed below.
 ## What apps could benefit?
 
 For each example below, developers have expressed interest in publishing a
-single installable app instead of one per origin with distinct app identities. 
+single installable app instead of one per origin with distinct [manifest
+ids](https://www.w3.org/TR/appmanifest/#id-member). 
 
 ### TLD locales
 
@@ -133,7 +134,8 @@ document in the app window is out-of-scope.
   how the manifest `scope` field works.
 
 - Allow web apps to capture user navigations to sites they are affiliated with.
-  E.g. "News Aggregator App" capturing links navigations to examplenewssite.com.
+  E.g. "Productivity Suite" app capturing links navigations to
+  presentations.productivity.com.
 
 ## Non-goals
 
@@ -180,7 +182,9 @@ extending its app scope to the origins `https://example.co.uk` and
 
 * Each entry in `scope_extensions` must contain both `type` and `value` string
 fields.
-* `type` must be `"origin"`. Other types could be added in the future.
+* `type` must be `"origin"`. Other types could be added in the future. One
+  future addition could be a `site` type which includes a dynamic number of
+  sub-domain origins (stated above as a non-goal). 
 * `value` must a valid URL. The URL is converted to an
   [origin](https://html.spec.whatwg.org/multipage/browsers.html#concept-origin-tuple). 
 
@@ -188,7 +192,7 @@ fields.
 
 A `web-app-origin-association` file must be served from
 `https://<associatedorigin>/.well-known/web-app-origin-association`. An app is
-allowed to extend its scope to this origin if their manifest ID is found in this
+allowed to extend its scope to this origin if their manifest id is found in this
 file.
 
 Example association file located at
@@ -202,15 +206,16 @@ Example association file located at
 }
 ```
 
-* Each dictionary key must be a validly formatted [web application
-id](https://w3c.github.io/manifest/#id-member).
+* Each dictionary key must be a validly formatted [manifest
+  id](https://w3c.github.io/manifest/#id-member).
 * Each dictionary value must be an object.
 * Each dictionary value can optionally contain a `scope` string. If not
   provided, `scope` defaults to `/`.
 * This `scope` configures the extension scope each identified app is allowed to
   utilize.
-* This `scope` works the same way as `scope` in the manifest and is relative to
-this origin. 
+* This `scope` works the same way as the
+[`scope`](https://www.w3.org/TR/appmanifest/#scope-member) member in the
+manifest and is relative to this origin. 
 
 ## Security Considerations
 


### PR DESCRIPTION
We want to split the current explainer into 2 parts. The first covers "origin" type extensions and all the additional information (association file, etc) needed for that. The 2nd part will propose the "site" type extensions and the additional security measures needed to enable that.

This PR edits the existing explainer to cover the first part.