### PR TITLE
Add `scope_extensions` member to manifest incubations spec

### DIFF
--- a/index.html
+++ b/index.html
@@ -1653,7 +1653,7 @@
           <ol>
             <li>
             If |entry| is not an [=ordered map=], or |entry|["scope"] does not
-              exist or is not a [=URL=], continue.</li>
+              [=map/exist=] or is not a [=URL=], continue.</li>
             <li>Let [=URL=] |resolved_scope:URL| be |entry:ordered
               map|["scope"]. </li>
             <li>If |target| is [=URL/within scope=] of |resolved_scope|, return
@@ -1731,12 +1731,12 @@
         </li>
         <li>Set |manifest|["scope_extensions"] to |processedScopeExtensions|.
         </li>
-        <li>If |json|["scope_extensions"] doesn't [=map/exist=] or is not a 
+        <li>If |json|["scope_extensions"] does not [=map/exist=] or is not a 
           [=list=], return.
         </li>
         <li>[=list/For each=] |entry:ordered map| of |json|["scope_extensions"]:
           <ol>
-            <li>If |entry|["type"] or |entry|["origin"] is undefined,
+            <li>If |entry|["type"] or |entry|["origin"] do not [=map/exist=],
               [=iteration/continue=].
             </li>
             <li>If |entry|["type"] is not "origin", [=iteration/continue=].
@@ -1793,19 +1793,19 @@
         <li>Let [=URL=] |origin_url:URL| be the [=URL=] of the [=URL/origin=]
           |extension|["origin"].</li>
         <li>Let [=URL=] |download_url:URL| be the result of [=URL
-          Parser|parsing=] the [=URL=] "/.well-known/web-app-origin-association"
-          using |origin_url| as the base [=URL=].
+          Parser|parsing=] "/.well-known/web-app-origin-association" using 
+          |origin_url| as the base [=URL=].
         </li>
         <li>Let [=ordered map=] |json:ordered map| be the result of a [=fetch=] 
-          using |download_url|. 
+          given |download_url|. 
         </li>
         <li>If the [=fetch=] failed, return an error.
         </li>
-        <li>If |json|[|manifest_id|] does not exist or is not an 
+        <li>If |json|[|manifest_id|] does not [=map/exist=] or is not an 
           [=ordered map=], return an error.</li>
         <li>Let [=string=] |scope:string| be "/".</li>
-        <li>If |json|[|manifest_id|]["scope"] exists and is a [=string=], set
-          |scope| to |json|[|manifest_id|]["scope"]. 
+        <li>If |json|[|manifest_id|]["scope"] [=map/exists=] and is a
+          [=string=], set |scope| to |json|[|manifest_id|]["scope"]. 
         </li>
         <li>Let [=URL=] |resolved_scope:URL| be the result of [=URL
           Parser|parsing=] |scope| with |extension|["origin"] as the base 

--- a/index.html
+++ b/index.html
@@ -1809,6 +1809,18 @@
       <p>The user agent MAY choose to apply <dfn>apply extended scope</dfn> in
         some scenarios and [=manifest/scope=] in others. 
       </p>
+      <p>
+        If the [=application context=]'s [=navigable/active document=]'s [=URL=]
+        is not [=manifest/within scope=] but is [=within extended scope=], the
+        user agent SHOULD provide UI that allows the user to determine the
+        [=URL=] or at least its [=origin=], including whether it is served over
+        a secure connection. This UI SHOULD differ from any UI used when the
+        [=URL=] is not [=manifest/within scope=] of the [=application
+        context=]'s [=Document/processed manifest=], in order to make it obvious
+        that the user is still navigating the intended contents of the
+        application but also keep the user informed of the privacy and security
+        implications of navigating to a different [=origin=].
+      </p>
     </section>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -1657,8 +1657,8 @@
               map|["scope"]. </li>
             <li>If |target| is [=URL/within scope=] of |resolved_scope|, return
               `true`.</li>
-            <li>Return `false`.</li>
           </ol>
+          <li>Return `false`.</li>
       </ol>
       <aside class="note">
         The [=manifest's=] `scope` member only allows URLs to be considered for scope

--- a/index.html
+++ b/index.html
@@ -1626,8 +1626,8 @@
       <p>
         Each <dfn>scope extension</dfn> extends the [=manifest/navigation scope
         of a manifest=] by describing [=URLs=] that should be treated as being 
-        [=manifest/within scope=]. [=Scope extensions=] can only add URLs to 
-        scope, not remove them.
+        [=manifest/within scope=]. [=Scope extensions=] can add URLs to scope 
+        but not remove them.
       </p>
       <p>
         The [=manifest's=] <code><dfn data-export="" data-dfn-for="manifest">
@@ -1693,6 +1693,26 @@
 
       <section>
       <h2>Processing the scope_extensions member</h2>
+      
+      <p>
+        An <dfn>extension type</dfn> represents a method of selecting URLs to be
+        added to the scope as an extension. 
+      </p>
+      <p>
+        This specification defines the following [=extension types=]:
+      </p>
+      <dl>
+        <dt>
+          <dfn class="export" data-dfn-for="extension type">origin</dfn>
+        </dt>
+        <dd>
+          Adds URLs from a single [=origin=] as a [=scope extension=].
+        </dd>
+      </dl>
+      <p>
+        The <dfn>extension types list</dfn> is the [=list=] 
+        « "[=extension type/origin=]" ».
+      </p>
       <p>
         To <dfn>process the `scope_extensions` member</dfn>, given
         [=ordered map=] |json:ordered map| and [=ordered map=]
@@ -1710,68 +1730,81 @@
           <ol>
             <li>If <var>entry</var>["type"] or <var>entry</var>["value"]
               is undefined, [=iteration/continue=].
-            <li>If <var>entry</var>["type"] is not "origin", 
-              [=iteration/continue=].
+            </li>
+            <li>If [=extension types list=] doesn't [=list/contain=]
+              |entry|["type"], [=iteration/continue=].
+            </li>
             <li>If <var>entry</var>["value"] is not a valid [=URL=], 
               [=iteration/continue=].
-            <li>Set <var>entry</var>["value"] to its [=origin=].
             </li>
-            <li>[=list/append=] <var>entry</var> to 
+            <li>Set <var>entry</var>["value"] to its own [=origin=].
+            </li>
+            <li>Validate |entry| using the steps from [=validate scope 
+              extensions=], given |entry|, [=boolean=] |succeeded:boolean|, 
+              [=URL=] |scope:URL|
+            </li>
+            <li>If |succeeded| is false, [=iteration/continue=].
+            </li>
+            <li>
+              Set |entry|["scope"] to |scope|.
+            </li>
+            <li>[=list/Append=] <var>entry</var> to 
               <var>processedScopeExtensions</var>.
-            </li>
             </li>
           </ol>
         </li>
-        <li>[=Validate scope extensions=] given |processedScopeExtensions|</li>
       </ol>
       </section>
-
       <section>
       <h2>Validating scope extensions</h2>
       <p>
-        To <dfn>validate scope extensions</dfn>, given
-        [=ordered map=] |manifest:ordered map|:
+        To <dfn>validate scope extension</dfn>, given [=ordered map=] 
+        |extension:ordered map|, [=boolean=] |succeeded:boolean|, and [=URL=] 
+        |scope:URL|:
       </p>
       <ol class="algorithm">
-        <!-- <li>Let |processedScopeExtensions:list| be a new [=list=].
+        <li>Let |download_url| be the result of constructing 
+          `web-app-origin-association` URL from the [=origin=] in 
+          |extension|["value"].
         </li>
-        <li>Set |manifest|["scope_extensions"] to |processedScopeExtensions|.
+        <li>Attempt to download the JSON file from |download_url|. 
         </li>
-        <li>If |json|["scope_extensions"] doesn't [=map/exist=] or
-          |json|["scope_extensions"] is not a [=list=], return.
+        <li>If the download fails, set |succeeded| to false and return.
         </li>
-        <li>[=list/For each=] <var>entry</var> of |json|["scope_extensions"]:
-          <ol>
-            <li>If <var>entry</var>["type"] or <var>entry</var>["value"]
-              is undefined, [=iteration/continue=].
-            <li>If <var>entry</var>["type"] is not "origin", 
-              [=iteration/continue=].
-            <li>If <var>entry</var>["value"] is not a valid [=URL=], 
-              [=iteration/continue=].
-            <li>Set <var>entry</var>["value"] to its [=origin=].
-            </li>
-            <li>[=list/append=] <var>entry</var> to 
-              <var>processedScopeExtensions</var>.
-            </li>
-            </li>
-          </ol>
-        </li> -->
+        <li>
+          Let downloaded content be |json:ordered map|.
+        </li>
+        <!-- TODO Let |association| be |json|["manifest id of app"].
+        TODO If |association| doesn't exist or is not a [=map=], set succeeded to false and return; -->
       </ol>
       </section>
 
     <section>
-      <h2>web-app-origin-association</h3>
-      <!-- TODO -->
-      <p>A <dfn>web-app-origin-association</dfn> file is... </p>
-    </section>
-
-    <section>
-      <h2>Processing the web-app-origin-association file</h3>
+      <h2>Processing the web-app-origin-association file</h2>
+      <p>A <dfn>web-app-origin-association</dfn> file is a JSON file that can be
+        used to associate the origin it is in with one or more web applications.
+        It does this by referencing manifest [=manifest/ids=]. 
+      </p>
+      <p>
+        A [=web-app-origin-association=] file is expected to be downloadable
+        from <code>[origin]/.well-known/web-app-origin-association</code>.
+      </p>
       <p>
         To <dfn>process the `web-app-origin-association` file</dfn>, given
         [=ordered map=] |json:ordered map| and [=ordered map=]
         |origin_associations:ordered map|:
-        <!-- TODO -->
+      <ol class="algorithm">
+
+        <li>Let |processedAssociations:ordered map| be a new [=ordered map=].
+        </li>
+
+        <li>Set |manifest|["scope_extensions"] to |processedScopeExtensions|.
+        </li>
+
+        <li>If |json|["scope_extensions"] doesn't [=map/exist=] or
+          |json|["scope_extensions"] is not a [=list=], return.
+        </li>
+      </ol>
       </p>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -1795,13 +1795,13 @@
         </li>
         <li>If |json|[|manifest_id|] does not exist or is not an 
           [=ordered map=], return an error.</li>
-        <li>Let [=string=] |scope_path:string| be "/".</li>
+        <li>Let [=string=] |scope:string| be "/".</li>
         <li>If |json|[|manifest_id|]["scope"] exists and is a [=string=], set
-          |scope_path| to |json|[|manifest_id|]["scope"]. 
+          |scope| to |json|[|manifest_id|]["scope"]. 
         </li>
         <li>Let [=URL=] |resolved_scope:URL| be the result of [=URL
-          Parser|parsing=] |scope_path| with |extension|["origin"] as the base
-          URL.
+          Parser|parsing=] |scope| with |extension|["origin"] as the base 
+          [=URL=].
         </li>
         <li>Return |resolved_scope|.</li>
       </ol>

--- a/index.html
+++ b/index.html
@@ -1618,7 +1618,6 @@
         <a>related applications</a> instead.
       </p>
     </section>
-
     <section>
       <h3>
         `scope_extensions` member
@@ -1631,8 +1630,8 @@
       </p>
       <p>
         The [=manifest's=] <code><dfn data-export="" data-dfn-for="manifest">
-          scope_extensions</dfn></code> member represents a list of desired
-          [=scope extensions=].
+          scope_extensions</dfn></code> member represents a list of an
+          application's desired [=scope extensions=].
       </p>
       <p>
         The user agent MUST [=process the scope_extensions member=] and 
@@ -1690,9 +1689,10 @@
           }
         </pre>
         <p> 
-          Thus the scope of this app includes all URLs that are
-          [=manifest/within scope=] of each of `https://example.com/app`, 
-          `https://example.co.uk/app`, and `https://help.example.com`. 
+          The navigation scope of this app should be all URLs that are 
+          [=manifest/within scope=] of each of 
+          `https://example.com/app`, `https://example.co.uk/app`, and 
+          `https://help.example.com`. 
         </p>
       </section>
       <section>
@@ -1740,7 +1740,7 @@
       </ol>
       <aside class="note">
         `origin` is the only type of scope extension entry that is 
-        currently supported. Other types may be added in the future to
+        currently specified. Other types may be added in the future to
         support different use cases. 
       </aside>
       </section>

--- a/index.html
+++ b/index.html
@@ -1624,9 +1624,8 @@
       </h3>
       <p>
         Each <dfn>scope extension</dfn> extends the [=manifest/navigation scope
-        of a manifest=] by describing [=URLs=] that should be treated as being 
-        [=manifest/within scope=]. [=Scope extensions=] can add URLs to scope 
-        but not remove them.
+        of a manifest=] by describing additional [=URLs=] that should be treated as
+        being [=manifest/within scope=].
       </p>
       <p>
         The [=manifest's=] <code><dfn data-export="" data-dfn-for="manifest">

--- a/index.html
+++ b/index.html
@@ -1651,8 +1651,9 @@
         <li>[=list/For each=] |entry:ordered map| of
           |validated_scope_extensions:list|:
           <ol>
+            <li>
             If |entry| is not an [=ordered map=], or |entry|["scope"] does not
-              exist or is not a [=URL=], continue.
+              exist or is not a [=URL=], continue.</li>
             <li>Let [=URL=] |resolved_scope:URL| be |entry:ordered
               map|["scope"]. </li>
             <li>If |target| is [=URL/within scope=] of |resolved_scope|, return

--- a/index.html
+++ b/index.html
@@ -1624,14 +1624,27 @@
         `scope_extensions` member
       </h3>
       <p>
-        <!-- TODO -->
-        A <dfn>scope extension</dfn> is a ... 
+        Each <dfn>scope extension</dfn> extends the [=manifest/navigation scope
+        of a manifest=] by describing groups of URLs that should be treated as
+        being [=manifest/within scope=].
       </p>
       <p>
+        The user agent MUST [=process the scope_extensions member=] and 
+        [=validate scope extensions=] to calculate [=scope extensions=] that 
+        should be applied.
+      </p>
+      <p>
+        The [=manifest's=] <code><dfn data-export="" data-dfn-for="manifest">
+          scope_extensions</dfn></code> member describes [=scope extensions=].
+      </p>
+
+      <p class="note">
         <!-- TODO -->
-        The [=manifest's=] <code><dfn data-export="" data-dfn-for=
-        "manifest">scope_extensions</dfn></code> member lists <a>scope
-        extensions</a> 
+         Talk about how [=URL/within scope=] needs to be modified...
+      </p>
+      <p class="note">
+        <!-- TODO -->
+         Talk about how `scope` only allows including URLs from a single origin to scope...
       </p>
 
       <section class="informative">
@@ -1674,6 +1687,7 @@
         </pre>
       </section>
 
+      <section>
       <h2>Processing the scope_extensions member</h2>
       <p>
         To <dfn>process the `scope_extensions` member</dfn>, given
@@ -1704,17 +1718,46 @@
             </li>
           </ol>
         </li>
+        <li>[=Validate scope extensions=] given |processedScopeExtensions|</li>
       </ol>
+      </section>
 
-      <h2>Validating the extensions</h2>
+      <section>
+      <h2>Validating scope extensions</h2>
       <p>
-        <!-- TODO -->
+        To <dfn>validate scope extensions</dfn>, given
+        [=ordered map=] |manifest:ordered map|:
       </p>
+      <ol class="algorithm">
+        <!-- <li>Let |processedScopeExtensions:list| be a new [=list=].
+        </li>
+        <li>Set |manifest|["scope_extensions"] to |processedScopeExtensions|.
+        </li>
+        <li>If |json|["scope_extensions"] doesn't [=map/exist=] or
+          |json|["scope_extensions"] is not a [=list=], return.
+        </li>
+        <li>[=list/For each=] <var>entry</var> of |json|["scope_extensions"]:
+          <ol>
+            <li>If <var>entry</var>["type"] or <var>entry</var>["value"]
+              is undefined, [=iteration/continue=].
+            <li>If <var>entry</var>["type"] is not "origin", 
+              [=iteration/continue=].
+            <li>If <var>entry</var>["value"] is not a valid [=URL=], 
+              [=iteration/continue=].
+            <li>Set <var>entry</var>["value"] to its [=origin=].
+            </li>
+            <li>[=list/append=] <var>entry</var> to 
+              <var>processedScopeExtensions</var>.
+            </li>
+            </li>
+          </ol>
+        </li> -->
+      </ol>
+      </section>
 
       <h3>web-app-origin-association</h3>
       <!-- TODO -->
       <p>A <dfn>web-app-origin-association file</dfn> is... </p>
-      <p>Handshake...</p>
 
       <h2>Processing the web-app-origin-association file</h3>
       <p>
@@ -1723,6 +1766,11 @@
         |origin_associations:ordered map|:
         <!-- TODO -->
       </p>
+    </section>
+
+    <section>
+      <h2>Applying scope extensions</h2>
+      <!-- TODO -->
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -1649,15 +1649,15 @@
       </p>
       <ol class="algorithm">
         <li>Let [=URL=] |resolved_scope:URL| be
-          |validated_scope_extensions:ordered map|["scope"]. </li>
+          |validated_scope_extension:ordered map|["scope"]. </li>
         <li>If |target| is [=URL/within scope=] of |resolved_scope|, return
           `true`.</li>
         <li>Return `false`.</li>
       </ol>
       <aside class="note">
-        The [=manifest's=] `scope` member only allows URLs to be added to scope
+        The [=manifest's=] `scope` member only allows URLs to be considered for scope
         from a single [=origin=]. The `scope_extensions` member allows URLs to
-        be added from multiple [=origins=].
+        be considered from multiple [=origins=].
       </aside>
       <section class="informative">
         <h2>

--- a/index.html
+++ b/index.html
@@ -1623,19 +1623,37 @@
         `scope_extensions` member
       </h3>
       <p>
-        Each <dfn>scope extension</dfn> extends the [=manifest/navigation scope
-        of a manifest=] by describing additional [=URLs=] that should be treated as
-        being [=manifest/within scope=].
-      </p>
-      <p>
         The [=manifest's=] <code><dfn data-export="" data-dfn-for="manifest">
           scope_extensions</dfn></code> member represents a list of an
           application's desired [=scope extensions=].
       </p>
       <p>
-        The user agent MUST [=process the scope_extensions member=] and 
-        [=validate scope extensions=] before they can be [=apply scope extensions/applied=] to allow more [=URLs=] to be [=manifest/within scope=].
+        A <dfn>scope extension</dfn> extends the [=manifest/navigation scope of
+        a manifest=] by describing additional [=URLs=] that should be treated as
+        being [=within extended scope=].
       </p>
+      <p>
+        The user agent MUST [=process the scope_extensions member=] and 
+        [=validate scope extensions=] before it can [=apply extended scope=] 
+        to allow additional [=URLs=] to be [=within extended scope=].
+      </p>
+      <p>
+        A [=URL=] |target:URL| is <dfn>within extended scope</dfn> of a
+        |manifest:processed manifest| if the |target| is [=manifest/within
+        scope=] of the manifest or [=matches a validated scope extension=]. 
+      </p>
+      <p>
+        A [=URL=] |target:URL| <dfn>matches a validated scope extension</dfn> if
+        the following algorithm returns `true`, given |target| and [=ordered map=]
+        |validated_scope_extension:ordered map|:
+      </p>
+      <ol class="algorithm">
+        <li>Let [=URL=] |resolved_scope:URL| be
+          |validated_scope_extensions:ordered map|["scope"]. </li>
+        <li>If |target| is [=URL/within scope=] of |resolved_scope|, return
+          `true`.</li>
+        <li>Return `false`.</li>
+      </ol>
       <aside class="note">
         The [=manifest's=] `scope` member only allows URLs to be added to scope
         from a single [=origin=]. The `scope_extensions` member allows URLs to
@@ -1646,8 +1664,8 @@
           Usage Example
         </h2>
         <p>
-          The following example shows a [=manifest=] for an application with 
-          extended scope.
+          The following example shows a [=manifest=] for an application which
+          uses the `scope_extensions` member.
         </p>
         <pre class="example json" 
           title="https://example.com/manifest.webmanifest">
@@ -1662,8 +1680,8 @@
             "scope": "/app",
             "display": "standalone",
             "scope_extensions": [
-              { "type": "origin", "value": "https://example.co.uk" },
-              { "type": "origin", "value": "https://help.example.com" }]
+              { "type": "origin", "origin": "https://example.co.uk" },
+              { "type": "origin", "origin": "https://help.example.com" }]
           }
         </pre>
         <p>
@@ -1688,8 +1706,8 @@
           }
         </pre>
         <p> 
-          The navigation scope of this app should be all URLs that are 
-          [=manifest/within scope=] of each of 
+          The navigation scope of this app consists of URLs that are 
+          [=URL/within scope=] of any of these [=URLs=]:
           `https://example.com/app`, `https://example.co.uk/app`, and 
           `https://help.example.com`. 
         </p>
@@ -1706,55 +1724,68 @@
         </li>
         <li>Set |manifest|["scope_extensions"] to |processedScopeExtensions|.
         </li>
-        <li>If |json|["scope_extensions"] doesn't [=map/exist=] or
-          |json|["scope_extensions"] is not a [=list=], return.
+        <li>If |json|["scope_extensions"] doesn't [=map/exist=] or is not a 
+          [=list=], return.
         </li>
-        <li>[=list/For each=] <var>entry</var> of |json|["scope_extensions"]:
+        <li>[=list/For each=] |entry:ordered map| of |json|["scope_extensions"]:
           <ol>
-            <li>If <var>entry</var>["type"] or <var>entry</var>["value"]
-              is undefined, [=iteration/continue=].
-            </li>
-            <li>If |entry|["type"] is not `origin`, 
+            <li>If |entry|["type"] or |entry|["origin"] is undefined,
               [=iteration/continue=].
             </li>
-            <li>If <var>entry</var>["value"] is not a valid [=URL=], 
+            <li>If |entry|["type"] is not "origin", [=iteration/continue=].
+            </li>
+            <li>If |entry|["origin"] is not a [=string=],
               [=iteration/continue=].
             </li>
-            <li>Set <var>entry</var>["value"] to its own [=origin=].
+            <li>Set |entry|["origin"] to the result of parsing it as an
+              [=origin=].
             </li>
-            <li>Validate |entry| using the steps from [=validate scope 
-              extensions=], given [=ordered map=] |entry:ordered map|, and 
-              [=URL=] |resolved_scope:URL|.
+            <li>Let [=URL=] |resolved_scope:URL| be an empty [=URL=]. </li>
+            <li>Validate |entry| using the algorithm from [=validate scope
+              extensions=], given [=ordered map=] |entry:ordered map|, [=URL=]
+              |manifest_id:URL|, and [=URL=] |resolved_scope:URL|. 
             </li>
             <li>If validation failed, [=iteration/continue=].
             </li>
             <li>
               Set |entry|["scope"] to |resolved_scope|.
             </li>
-            <li>[=list/Append=] <var>entry</var> to 
-              <var>processedScopeExtensions</var>.
+            <li>[=list/Append=] |entry| to |processedScopeExtensions|.
             </li>
           </ol>
         </li>
       </ol>
       <aside class="note">
-        `origin` is the only type of scope extension entry that is 
-        currently specified. Other types may be added in the future to
-        support different use cases. 
+        `origin` is the only type of scope extension entry that is currently
+        specified. Other types may be added in the future to support different
+        use cases. 
       </aside>
+      </section>
+      <section class="informative">
+        <h3>The web-app-origin-association file</h3>
+        <p>A <dfn>web-app-origin-association</dfn> file is a JSON file that can
+          be used to [=validate scope extensions=]. It confirm an association
+          between the origin it is in with one or more web applications. It 
+          identifies apps uniquely by referencing manifest [=manifest/ids=]. 
+        </p>
+        <p>
+          Given [=origin=] |origin:origin|, a [=web-app-origin-association=]
+          file is expected to be downloadable from 
+          <code>[origin]/.well-known/web-app-origin-association</code>.
+        </p>
       </section>
       <section>
       <h2>Validating scope extensions</h2>
       <p>
-        To <dfn>validate scope extension</dfn>, given [=ordered map=] 
+        To <dfn>validate scope extensions</dfn>, given [=ordered map=] 
         |extension:ordered map|, [=URL=] |manifest_id:URL| and [=URL=] 
         |resolved_scope:URL|:
       </p>
       <ol class="algorithm">
         <li>Set |resolved_scope| to empty URL.</li>
-        <li>Let |download_url| be the result of constructing 
-          [=web-app-origin-association=] URL from the [=origin=] in 
-          |extension|["value"].
+        <li>Let [=URL=] |download_url| be the result of parsing 
+          "/.well-known/web-app-origin-association" using |extension|["origin"] 
+          as the base [=URL=].
         </li>
         <li>Let [=ordered map=] |json:ordered map| be the result of downloading
           |download_url|. 
@@ -1764,29 +1795,19 @@
         <li>If |json|[|manifest_id|] does not exist or is not an 
           [=ordered map=], return false.</li>
         <li>Let [=string=] |scope_path:string| be "/".</li>
-
-        <li>If |json|[|manifest_id|]["scope"] exists and is [=string=], 
-          set |scope_path| to |json|[|manifest_id|]["scope"]. 
+        <li>If |json|[|manifest_id|]["scope"] exists and is a [=string=], set
+          |scope_path| to |json|[|manifest_id|]["scope"]. 
         </li>
         <li>Set |resolved_scope:URL| be the result of parsing |scope_path| with 
-          |extension|["value"] as the base URL.
+          |extension|["origin"] as the base URL.
         </li>
         <li>return true.</li>
       </ol>
-      <h3>The web-app-origin-association file</h3>
-      <p>A <dfn>web-app-origin-association</dfn> file is a JSON file that can be
-        used to associate the origin it is in with one or more web applications.
-        It does this by referencing manifest [=manifest/ids=]. 
-      </p>
-      <p>
-        A [=web-app-origin-association=] file is expected to be downloadable
-        from <code>[origin]/.well-known/web-app-origin-association</code>.
-      </p>
     </section>
     <section>
       <h2>Applying scope extensions</h2>
-      <p>The user agent MAY apply extended scope to some features but 
-        not others.
+      <p>The user agent MAY choose to apply <dfn>apply extended scope</dfn> in
+        some scenarios and [=manifest/scope=] in others. 
       </p>
     </section>
     </section>

--- a/index.html
+++ b/index.html
@@ -1715,9 +1715,8 @@
       <section>
       <h2>Processing the scope_extensions member</h2>
       <p>
-        To <dfn>process the `scope_extensions` member</dfn>, given
-        [=ordered map=] |json:ordered map| and [=ordered map=]
-        |manifest:ordered map|:
+        To <dfn>process the `scope_extensions` member</dfn>, given [=ordered
+        map=] |json:ordered map| and [=ordered map=] |manifest:ordered map|:
       </p>
       <ol class="algorithm">
         <li>Let |processedScopeExtensions:list| be a new [=list=].
@@ -1737,18 +1736,20 @@
             <li>If |entry|["origin"] is not a [=string=],
               [=iteration/continue=].
             </li>
-            <li>Set |entry|["origin"] to the result of parsing it as an
-              [=origin=].
+            <li>Let [=URL=] |origin_url:URL| be the result of [=URL
+              Parser|parsing=] |entry|["origin"].
             </li>
-            <li>Let [=URL=] |resolved_scope:URL| be an empty [=URL=]. </li>
+            <li>If |origin_url| is a valid |URL| with [=URL/scheme=] "https",
+              set |entry|["origin"] to the [=URL/origin=] of |origin_url|.
+            <li>Else [=iteration/continue=].</li>
             <li>Validate |entry| using the algorithm from [=validate scope
-              extensions=], given [=ordered map=] |entry:ordered map|, [=URL=]
-              |manifest_id:URL|, and [=URL=] |resolved_scope:URL|. 
+              extensions=], given [=ordered map=] |entry:ordered map|, and 
+              [=URL=] |manifest_id:URL|. 
             </li>
-            <li>If validation failed, [=iteration/continue=].
+            <li>If the previous step returned an error, [=iteration/continue=].
             </li>
             <li>
-              Set |entry|["scope"] to |resolved_scope|.
+              Else, set |entry|["scope"] to the returned [=URL=].
             </li>
             <li>[=list/Append=] |entry| to |processedScopeExtensions|.
             </li>
@@ -1778,30 +1779,31 @@
       <h2>Validating scope extensions</h2>
       <p>
         To <dfn>validate scope extensions</dfn>, given [=ordered map=] 
-        |extension:ordered map|, [=URL=] |manifest_id:URL| and [=URL=] 
-        |resolved_scope:URL|:
+        |extension:ordered map| and [=URL=] |manifest_id:URL|:
       </p>
       <ol class="algorithm">
-        <li>Set |resolved_scope| to empty URL.</li>
-        <li>Let [=URL=] |download_url| be the result of parsing 
-          "/.well-known/web-app-origin-association" using |extension|["origin"] 
-          as the base [=URL=].
+        <li>Let [=URL=] |origin_url:URL| be the [=URL=] of the [=URL/origin=]
+          |extension|["origin"].</li>
+        <li>Let [=URL=] |download_url:URL| be the result of [=URL
+          Parser|parsing=] the [=URL=] "/.well-known/web-app-origin-association"
+          using |origin_url| as the base [=URL=].
         </li>
-        <li>Let [=ordered map=] |json:ordered map| be the result of downloading
-          |download_url|. 
+        <li>Let [=ordered map=] |json:ordered map| be the result of a [=fetch=] 
+          using |download_url|. 
         </li>
-        <li>If the download fails, return false.
+        <li>If the [=fetch=] failed, return an error.
         </li>
         <li>If |json|[|manifest_id|] does not exist or is not an 
-          [=ordered map=], return false.</li>
+          [=ordered map=], return an error.</li>
         <li>Let [=string=] |scope_path:string| be "/".</li>
         <li>If |json|[|manifest_id|]["scope"] exists and is a [=string=], set
           |scope_path| to |json|[|manifest_id|]["scope"]. 
         </li>
-        <li>Set |resolved_scope:URL| be the result of parsing |scope_path| with 
-          |extension|["origin"] as the base URL.
+        <li>Let [=URL=] |resolved_scope:URL| be the result of [=URL
+          Parser|parsing=] |scope_path| with |extension|["origin"] as the base
+          URL.
         </li>
-        <li>return true.</li>
+        <li>Return |resolved_scope|.</li>
       </ol>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -1757,23 +1757,22 @@
           [=web-app-origin-association=] URL from the [=origin=] in 
           |extension|["value"].
         </li>
-        <li>Attempt to download the JSON file from |download_url|. 
+        <li>Let [=ordered map=] |json:ordered map| be the result of downloading
+          |download_url|. 
         </li>
         <li>If the download fails, return false.
         </li>
-        <li>
-          Let downloaded file be |json:ordered map|.
-        </li>
         <li>If |json|[|manifest_id|] does not exist or is not an 
-          [=ordered map=], return false</li>
-        <li>If |json|[|manifest_id|]["scope"] does not exist or is not 
-          [=string=], return false</li>
-        <li>Let [=string=] |scope_path:string| be 
-          |json|[|manifest_id|]["scope"]</li>
-        <li>Let [=URL] |resolved_scope:URL| be the result of resolving
-          |scope_path| against the origin |extension|["value"].
+          [=ordered map=], return false.</li>
+        <li>Let [=string=] |scope_path:string| be "/".</li>
+
+        <li>If |json|[|manifest_id|]["scope"] exists and is [=string=], 
+          set |scope_path| to |json|[|manifest_id|]["scope"]. 
         </li>
-        <li>return true</li>
+        <li>Set |resolved_scope:URL| be the result of parsing |scope_path| with 
+          |extension|["value"] as the base URL.
+        </li>
+        <li>return true.</li>
       </ol>
       <h3>The web-app-origin-association file</h3>
       <p>A <dfn>web-app-origin-association</dfn> file is a JSON file that can be

--- a/index.html
+++ b/index.html
@@ -1651,8 +1651,10 @@
         <li>[=list/For each=] |entry:ordered map| of
           |validated_scope_extensions:list|:
           <ol>
-            <li>Let [=URL=] |resolved_scope:URL| be
-              |validated_scope_extension:ordered map|["scope"]. </li>
+            If |entry| is not an [=ordered map=], or |entry|["scope"] does not
+              exist or is not a [=URL=], continue.
+            <li>Let [=URL=] |resolved_scope:URL| be |entry:ordered
+              map|["scope"]. </li>
             <li>If |target| is [=URL/within scope=] of |resolved_scope|, return
               `true`.</li>
             <li>Return `false`.</li>

--- a/index.html
+++ b/index.html
@@ -1638,21 +1638,21 @@
         The user agent MUST [=process the scope_extensions member=] and 
         [=validate scope extensions=] before applying them.
       </p>
-      <p class="note">
+      <aside class="note">
         The [=manifest's=] `scope` member only allows URLs to be added to scope
         from a single [=origin=]. The `scope_extensions` member allows URLs to
         be added from multiple [=origins=].
-      </p>
+      </aside>
       <section class="informative">
         <h2>
           Usage Example
         </h2>
         <p>
-          The following shows a [=manifest=] for an application with extended
-          scope. The [=manifest url=] is 
-          `https://example.com/manifest.webmanifest`.
+          The following example shows a [=manifest=] for an application with 
+          extended scope.
         </p>
-        <pre class="example json" title="Manifest with scope_extensions">
+        <pre class="example json" 
+          title="https://example.com/manifest.webmanifest">
           {
             "id": "https://example.com/app",
             "name": "My App",
@@ -1689,30 +1689,14 @@
             }
           }
         </pre>
+        <p> 
+          Thus the scope of this app includes all URLs that are
+          [=manifest/within scope=] of each of `https://example.com/app`, 
+          `https://example.co.uk/app`, and `https://help.example.com`. 
+        </p>
       </section>
-
       <section>
       <h2>Processing the scope_extensions member</h2>
-      
-      <p>
-        An <dfn>extension type</dfn> represents a method of selecting URLs to be
-        added to the scope as an extension. 
-      </p>
-      <p>
-        This specification defines the following [=extension types=]:
-      </p>
-      <dl>
-        <dt>
-          <dfn class="export" data-dfn-for="extension type">origin</dfn>
-        </dt>
-        <dd>
-          Adds URLs from a single [=origin=] as a [=scope extension=].
-        </dd>
-      </dl>
-      <p>
-        The <dfn>extension types list</dfn> is the [=list=] 
-        « "[=extension type/origin=]" ».
-      </p>
       <p>
         To <dfn>process the `scope_extensions` member</dfn>, given
         [=ordered map=] |json:ordered map| and [=ordered map=]
@@ -1731,8 +1715,8 @@
             <li>If <var>entry</var>["type"] or <var>entry</var>["value"]
               is undefined, [=iteration/continue=].
             </li>
-            <li>If [=extension types list=] doesn't [=list/contain=]
-              |entry|["type"], [=iteration/continue=].
+            <li>If |entry|["type"] is not `origin`, 
+              [=iteration/continue=].
             </li>
             <li>If <var>entry</var>["value"] is not a valid [=URL=], 
               [=iteration/continue=].
@@ -1740,13 +1724,13 @@
             <li>Set <var>entry</var>["value"] to its own [=origin=].
             </li>
             <li>Validate |entry| using the steps from [=validate scope 
-              extensions=], given |entry|, [=boolean=] |succeeded:boolean|, 
-              [=URL=] |scope:URL|
+              extensions=], given [=ordered map=] |entry:ordered map|, and 
+              [=URL=] |resolved_scope:URL|.
             </li>
-            <li>If |succeeded| is false, [=iteration/continue=].
+            <li>If validation failed, [=iteration/continue=].
             </li>
             <li>
-              Set |entry|["scope"] to |scope|.
+              Set |entry|["scope"] to |resolved_scope|.
             </li>
             <li>[=list/Append=] <var>entry</var> to 
               <var>processedScopeExtensions</var>.
@@ -1754,33 +1738,44 @@
           </ol>
         </li>
       </ol>
+      <aside class="note">
+        `origin` is the only type of scope extension entry that is 
+        currently supported. Other types may be added in the future to
+        support different use cases. 
+      </aside>
       </section>
       <section>
       <h2>Validating scope extensions</h2>
       <p>
         To <dfn>validate scope extension</dfn>, given [=ordered map=] 
-        |extension:ordered map|, [=boolean=] |succeeded:boolean|, and [=URL=] 
-        |scope:URL|:
+        |extension:ordered map|, [=URL=] |manifest_id:URL| and [=URL=] 
+        |resolved_scope:URL|:
       </p>
       <ol class="algorithm">
+        <li>Set |resolved_scope| to empty URL.</li>
         <li>Let |download_url| be the result of constructing 
-          `web-app-origin-association` URL from the [=origin=] in 
+          [=web-app-origin-association=] URL from the [=origin=] in 
           |extension|["value"].
         </li>
         <li>Attempt to download the JSON file from |download_url|. 
         </li>
-        <li>If the download fails, set |succeeded| to false and return.
+        <li>If the download fails, return false.
         </li>
         <li>
-          Let downloaded content be |json:ordered map|.
+          Let downloaded file be |json:ordered map|.
         </li>
-        <!-- TODO Let |association| be |json|["manifest id of app"].
-        TODO If |association| doesn't exist or is not a [=map=], set succeeded to false and return; -->
+        <li>If |json|[|manifest_id|] does not exist or is not an 
+          [=ordered map=], return false</li>
+        <li>If |json|[|manifest_id|]["scope"] does not exist or is not 
+          [=string=], return false</li>
+        <li>Let [=string=] |scope_path:string| be 
+          |json|[|manifest_id|]["scope"]</li>
+        <li>Let [=URL] |resolved_scope:URL| be the result of resolving
+          |scope_path| against the origin |extension|["value"].
+        </li>
+        <li>return true</li>
       </ol>
-      </section>
-
-    <section>
-      <h2>Processing the web-app-origin-association file</h2>
+      <h3>The web-app-origin-association file</h3>
       <p>A <dfn>web-app-origin-association</dfn> file is a JSON file that can be
         used to associate the origin it is in with one or more web applications.
         It does this by referencing manifest [=manifest/ids=]. 
@@ -1789,30 +1784,14 @@
         A [=web-app-origin-association=] file is expected to be downloadable
         from <code>[origin]/.well-known/web-app-origin-association</code>.
       </p>
-      <p>
-        To <dfn>process the `web-app-origin-association` file</dfn>, given
-        [=ordered map=] |json:ordered map| and [=ordered map=]
-        |origin_associations:ordered map|:
-      <ol class="algorithm">
-
-        <li>Let |processedAssociations:ordered map| be a new [=ordered map=].
-        </li>
-
-        <li>Set |manifest|["scope_extensions"] to |processedScopeExtensions|.
-        </li>
-
-        <li>If |json|["scope_extensions"] doesn't [=map/exist=] or
-          |json|["scope_extensions"] is not a [=list=], return.
-        </li>
-      </ol>
-      </p>
     </section>
     <section>
       <h2>Applying scope extensions</h2>
-      <!-- TODO -->
+      <p>The user agent MAY apply extended scope to some features but 
+        not others.
+      </p>
     </section>
     </section>
-
     <section>
       <h2>
         External application resource

--- a/index.html
+++ b/index.html
@@ -1634,7 +1634,7 @@
       </p>
       <p>
         The user agent MUST [=process the scope_extensions member=] and 
-        [=validate scope extensions=] before applying them.
+        [=validate scope extensions=] before they can be [=apply scope extensions/applied=] to allow more [=URLs=] to be [=manifest/within scope=].
       </p>
       <aside class="note">
         The [=manifest's=] `scope` member only allows URLs to be added to scope

--- a/index.html
+++ b/index.html
@@ -238,6 +238,9 @@
         <li>[=Process the `related_applications` member=], passing |json| and
         |manifest|.
         </li>
+        <li>[=Process the `scope_extensions` member=], passing |json| and
+        |manifest|.
+        </li>
       </ol>
     </section>
     <section>
@@ -1615,6 +1618,113 @@
         <a>related applications</a> instead.
       </p>
     </section>
+
+    <section>
+      <h3>
+        `scope_extensions` member
+      </h3>
+      <p>
+        <!-- TODO -->
+        A <dfn>scope extension</dfn> is a ... 
+      </p>
+      <p>
+        <!-- TODO -->
+        The [=manifest's=] <code><dfn data-export="" data-dfn-for=
+        "manifest">scope_extensions</dfn></code> member lists <a>scope
+        extensions</a> 
+      </p>
+
+      <section class="informative">
+        <h2>
+          Usage Example
+        </h2>
+        <p>
+          The following shows a [=manifest=] for an application with extended
+          scope. The manifest [=URL=] is 
+          "https://example.com/manifest.webmanifest".
+        </p>
+        <pre class="example json" title="Application with extended scope">
+          {
+            "id": "https://example.com/app",
+            "name": "My App",
+            "icons": [{
+              "src": "icon/hd_hi",
+              "sizes": "128x128"
+            }],
+            "start_url": "/app/index.html",
+            "scope": "/app",
+            "display": "standalone",
+            "scope_extensions": [
+              { "type": "origin", "value": "https://example.co.uk" },
+              { "type": "origin", "value": "https://help.example.com" }]
+          }
+        </pre>
+        <p>
+          The following shows a [=web-app-origin-association file=] hosted at 
+          "https://example.co.uk/.well-known/web-app-origin-association". This
+          file is hosted at the same [=origin=] used in the [=scope extension=]
+          above.
+        </p>
+        <pre class="example json" title="web-app-origin-association">
+          {
+            "https://example.com/app": {
+              "scope": "/app"   
+            }
+          }
+        </pre>
+      </section>
+
+      <h2>Processing the scope_extensions member</h2>
+      <p>
+        To <dfn>process the `scope_extensions` member</dfn>, given
+        [=ordered map=] |json:ordered map| and [=ordered map=]
+        |manifest:ordered map|:
+      </p>
+      <ol class="algorithm">
+        <li>Let |processedScopeExtensions:list| be a new [=list=].
+        </li>
+        <li>Set |manifest|["scope_extensions"] to |processedScopeExtensions|.
+        </li>
+        <li>If |json|["scope_extensions"] doesn't [=map/exist=] or
+          |json|["scope_extensions"] is not a [=list=], return.
+        </li>
+        <li>[=list/For each=] <var>entry</var> of |json|["scope_extensions"]:
+          <ol>
+            <li>If <var>entry</var>["type"] or <var>entry</var>["value"]
+              is undefined, [=iteration/continue=].
+            <li>If <var>entry</var>["type"] is not "origin", 
+              [=iteration/continue=].
+            <li>If <var>entry</var>["value"] is not a valid [=URL=], 
+              [=iteration/continue=].
+            <li>Set <var>entry</var>["value"] to its [=origin=].
+            </li>
+            <li>[=list/append=] <var>entry</var> to 
+              <var>processedScopeExtensions</var>.
+            </li>
+            </li>
+          </ol>
+        </li>
+      </ol>
+
+      <h2>Validating the extensions</h2>
+      <p>
+        <!-- TODO -->
+      </p>
+
+      <h3>web-app-origin-association</h3>
+      <!-- TODO -->
+      <p>A <dfn>web-app-origin-association file</dfn> is... </p>
+      <p>Handshake...</p>
+
+      <h2>Processing the web-app-origin-association file</h3>
+      <p>
+        To <dfn>process the `web-app-origin-association` file</dfn>, given
+        [=ordered map=] |json:ordered map| and [=ordered map=]
+        |origin_associations:ordered map|:
+        <!-- TODO -->
+      </p>
+    </section>
+
     <section>
       <h2>
         External application resource

--- a/index.html
+++ b/index.html
@@ -1644,15 +1644,19 @@
       </p>
       <p>
         A [=URL=] |target:URL| <dfn>matches a validated scope extension</dfn> if
-        the following algorithm returns `true`, given |target| and [=ordered map=]
-        |validated_scope_extension:ordered map|:
+        the following algorithm returns `true`, given [=URL=] |target:URL| and
+        [=list=] |validated_scope_extensions:list|:
       </p>
       <ol class="algorithm">
-        <li>Let [=URL=] |resolved_scope:URL| be
-          |validated_scope_extension:ordered map|["scope"]. </li>
-        <li>If |target| is [=URL/within scope=] of |resolved_scope|, return
-          `true`.</li>
-        <li>Return `false`.</li>
+        <li>[=list/For each=] |entry:ordered map| of
+          |validated_scope_extensions:list|:
+          <ol>
+            <li>Let [=URL=] |resolved_scope:URL| be
+              |validated_scope_extension:ordered map|["scope"]. </li>
+            <li>If |target| is [=URL/within scope=] of |resolved_scope|, return
+              `true`.</li>
+            <li>Return `false`.</li>
+          </ol>
       </ol>
       <aside class="note">
         The [=manifest's=] `scope` member only allows URLs to be considered for scope
@@ -1744,7 +1748,7 @@
               set |entry|["origin"] to the [=URL/origin=] of |origin_url|.
             <li>Else [=iteration/continue=].</li>
             <li>Validate |entry| using the algorithm from [=validate scope
-              extensions=], given [=ordered map=] |entry:ordered map|, and 
+              extensions=], given [=ordered map=] |entry:ordered map| and 
               [=URL=] |manifest_id:URL|. 
             </li>
             <li>If the previous step returned an error, [=iteration/continue=].

--- a/index.html
+++ b/index.html
@@ -1755,10 +1755,13 @@
       </ol>
       </section>
 
-      <h3>web-app-origin-association</h3>
+    <section>
+      <h2>web-app-origin-association</h3>
       <!-- TODO -->
       <p>A <dfn>web-app-origin-association file</dfn> is... </p>
+    </section>
 
+    <section>
       <h2>Processing the web-app-origin-association file</h3>
       <p>
         To <dfn>process the `web-app-origin-association` file</dfn>, given
@@ -1767,10 +1770,10 @@
         <!-- TODO -->
       </p>
     </section>
-
     <section>
       <h2>Applying scope extensions</h2>
       <!-- TODO -->
+    </section>
     </section>
 
     <section>

--- a/index.html
+++ b/index.html
@@ -1713,10 +1713,11 @@
         </p>
       </section>
       <section>
-      <h2>Processing the scope_extensions member</h2>
+      <h2>Processing the `scope_extensions` member</h2>
       <p>
         To <dfn>process the `scope_extensions` member</dfn>, given [=ordered
-        map=] |json:ordered map| and [=ordered map=] |manifest:ordered map|:
+        map=] |json:ordered map|, [=ordered map=] |manifest:ordered map|, and
+        [=URL=] |manifest_id:URL|:
       </p>
       <ol class="algorithm">
         <li>Let |processedScopeExtensions:list| be a new [=list=].

--- a/index.html
+++ b/index.html
@@ -1625,38 +1625,34 @@
       </h3>
       <p>
         Each <dfn>scope extension</dfn> extends the [=manifest/navigation scope
-        of a manifest=] by describing groups of URLs that should be treated as
-        being [=manifest/within scope=].
-      </p>
-      <p>
-        The user agent MUST [=process the scope_extensions member=] and 
-        [=validate scope extensions=] to calculate [=scope extensions=] that 
-        should be applied.
+        of a manifest=] by describing [=URLs=] that should be treated as being 
+        [=manifest/within scope=]. [=Scope extensions=] can only add URLs to 
+        scope, not remove them.
       </p>
       <p>
         The [=manifest's=] <code><dfn data-export="" data-dfn-for="manifest">
-          scope_extensions</dfn></code> member describes [=scope extensions=].
+          scope_extensions</dfn></code> member represents a list of desired
+          [=scope extensions=].
       </p>
-
+      <p>
+        The user agent MUST [=process the scope_extensions member=] and 
+        [=validate scope extensions=] before applying them.
+      </p>
       <p class="note">
-        <!-- TODO -->
-         Talk about how [=URL/within scope=] needs to be modified...
+        The [=manifest's=] `scope` member only allows URLs to be added to scope
+        from a single [=origin=]. The `scope_extensions` member allows URLs to
+        be added from multiple [=origins=].
       </p>
-      <p class="note">
-        <!-- TODO -->
-         Talk about how `scope` only allows including URLs from a single origin to scope...
-      </p>
-
       <section class="informative">
         <h2>
           Usage Example
         </h2>
         <p>
           The following shows a [=manifest=] for an application with extended
-          scope. The manifest [=URL=] is 
-          "https://example.com/manifest.webmanifest".
+          scope. The [=manifest url=] is 
+          `https://example.com/manifest.webmanifest`.
         </p>
-        <pre class="example json" title="Application with extended scope">
+        <pre class="example json" title="Manifest with scope_extensions">
           {
             "id": "https://example.com/app",
             "name": "My App",
@@ -1673,15 +1669,23 @@
           }
         </pre>
         <p>
-          The following shows a [=web-app-origin-association file=] hosted at 
-          "https://example.co.uk/.well-known/web-app-origin-association". This
-          file is hosted at the same [=origin=] used in the [=scope extension=]
-          above.
+          The following shows 2 [=web-app-origin-association=] files which can
+          be downloaded from the `.well-known` path of the [=origins=]  listed 
+          in the `scope_extensions` member.
         </p>
-        <pre class="example json" title="web-app-origin-association">
+        <pre class="example json" 
+        title="https://example.co.uk/.well-known/web-app-origin-association">
           {
             "https://example.com/app": {
               "scope": "/app"   
+            }
+          }
+        </pre>
+        <pre class="example json" 
+        title="https://help.example.com/.well-known/web-app-origin-association">
+          {
+            "https://example.com/app": {
+              "scope": "/"   
             }
           }
         </pre>
@@ -1758,7 +1762,7 @@
     <section>
       <h2>web-app-origin-association</h3>
       <!-- TODO -->
-      <p>A <dfn>web-app-origin-association file</dfn> is... </p>
+      <p>A <dfn>web-app-origin-association</dfn> file is... </p>
     </section>
 
     <section>


### PR DESCRIPTION
Add `scope_extensions` member to manifest incubations spec

Spec implementation of the `scope_extension` [explainer](https://github.com/WICG/manifest-incubations/blob/gh-pages/scope_extensions-explainer.md).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/WICG/manifest-incubations/pull/113.html" title="Last updated on May 29, 2025, 1:03 AM UTC (d7e2ede)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/manifest-incubations/113/2c02a88...d7e2ede.html" title="Last updated on May 29, 2025, 1:03 AM UTC (d7e2ede)">Diff</a>