### PR TITLE
Set `targetURL` in file handler execution

### DIFF
--- a/index.html
+++ b/index.html
@@ -1419,9 +1419,10 @@
                   <li>[=list/for each=] |file| of |files|
                     <ol>
                       <li>Let |params:LaunchParams| be a new {{LaunchParams}}
-                      with {{LaunchParams/files}} set to a {{FrozenArray}} with
-                      a single element that is a {{FileSystemHandle}}
-                      corresponding to |file|.
+                      with {{LaunchParams/targetURL}} set to
+                      |file_handler|["action"] and {{LaunchParams/files}} set
+                      to a {{FrozenArray}} with a single element that is a
+                      {{FileSystemHandle}} corresponding to |file|.
                       </li>
                       <li>[=Launch a web application with handling=], passing
                       |manifest| and |params|.
@@ -1433,7 +1434,8 @@
               <li>Else,
                 <ol>
                   <li>Let |params:LaunchParams| be a new {{LaunchParams}} with
-                  {{LaunchParams/files}} set to a {{FrozenArray}} of
+                  {{LaunchParams/targetURL}} set to |file_handler|["action"]
+                  and {{LaunchParams/files}} set to a {{FrozenArray}} of
                   {{FileSystemHandle}}s that correspond to the file paths named
                   by |files|.
                   </li>


### PR DESCRIPTION
This change documents that the `targetURL` should be set for file_handler execution.

Fixes https://github.com/WICG/web-app-launch/issues/97


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/dmurph/manifest-incubations/pull/134.html" title="Last updated on Jan 22, 2026, 7:22 PM UTC (9a58e96)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/WICG/manifest-incubations/134/35dad17...dmurph:9a58e96.html" title="Last updated on Jan 22, 2026, 7:22 PM UTC (9a58e96)">Diff</a>